### PR TITLE
A script for creating hipified commits

### DIFF
--- a/script/extend-hipify-branch.sh
+++ b/script/extend-hipify-branch.sh
@@ -3,17 +3,36 @@
 # Hipifies the current working tree and adds the changes to the tip of the
 # hipified branch, using the current commit as the second parent of a merge
 # commit with the working tree matching the hipified state.
+#
+# So when a new commit is added to hip-ready, you can run this script to achieve
+# the following history change, where the working tree of commit X' is the
+# result of hipifying commit X.
+#
+# Before:
+#
+# hipify-inplace    A'--B'------D'
+#                  /   /       /
+# hip-ready       A---B---C---D---E
+#
+# After:
+#
+# hipify-inplace    A'--B'------D'--E'
+#                  /   /       /   /
+# hip-ready       A---B---C---D---E
+
 
 # Note that this uses low-level git commands to construct a commit with the
-# working tree and parent relationships that we want.
+# working tree and parent relationships that we want as doing so with
+# higher-level commands like git commit and git merge is quite tricky because
+# the "smarts" of these commands actually get in the way.
 
 set -euo pipefail
 
 HIPIFIED_BRANCH="${1:-hipify-inplace}"
 
 function main() {
-    local tmp_branch="hipify-$(echo "${RANDOM}" | md5sum | head -c 5)"
     local hip_ready_sha="$(git rev-parse HEAD)"
+    local tmp_branch="hipify-$(echo "${hip_ready_sha}" | head -c 5)"
     local message="Hipify from nod-ai/dgl@${hip_ready_sha:0:10}"
     
     # Hipify the current working tree on a new temporary branch.
@@ -29,7 +48,7 @@ function main() {
     git switch "${HIPIFIED_BRANCH}"
 
     # Here we manually construct a git commit using low-level commands. The
-    # working tree is taken from the commit we just created on ${branch_name}
+    # working tree is taken from the commit we just created on ${tmp_branch}
     # and the parents are specified as the current HEAD of ${HIPIFIED_BRANCH}
     # and the HEAD of the branch we are hipifying from (in that order). See
     # https://stackoverflow.com/q/48560351.

--- a/script/extend-hipify-branch.sh
+++ b/script/extend-hipify-branch.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Hipifies the current working tree and adds the changes to the tip of the
+# hipified branch, using the current commit as the second parent of a merge
+# commit with the working tree matching the hipified state.
+
+# Note that this uses low-level git commands to construct a commit with the
+# working tree and parent relationships that we want.
+
+set -euo pipefail
+
+HIPIFIED_BRANCH="${1:-hipify-inplace}"
+
+function main() {
+    local tmp_branch="hipify-$(echo "${RANDOM}" | md5sum | head -c 5)"
+    local hip_ready_sha="$(git rev-parse HEAD)"
+    local message="Hipify from nod-ai/dgl@${hip_ready_sha:0:10}"
+    
+    # Hipify the current working tree on a new temporary branch.
+    git switch -c "${tmp_branch}"
+    echo "Running hipify script"
+    script/hipify-inplace.sh
+
+    # Create a commit with the hipified changes.
+    echo "Committing hipified changes"
+    git add -A
+    git commit -m "${message}"
+
+    git switch "${HIPIFIED_BRANCH}"
+
+    # Here we manually construct a git commit using low-level commands. The
+    # working tree is taken from the commit we just created on ${branch_name}
+    # and the parents are specified as the current HEAD of ${HIPIFIED_BRANCH}
+    # and the HEAD of the branch we are hipifying from (in that order). See
+    # https://stackoverflow.com/q/48560351.
+    echo "Constructing new merge commit"
+    local new_commit="$(git commit-tree -m "${message}" "${tmp_branch}^{tree}" -p HEAD -p "${hip_ready_sha}")"
+    echo "Resetting ${HIPIFIED_BRANCH} to new commit ${new_commit:0:10}"
+    # Then we set the hipified branch to point to the new commit.
+    git reset --hard "${new_commit}"
+    echo "Cleaning up temporary branch ${tmp_branch}"
+    git branch -D "${tmp_branch}"
+    git log -n 20 --graph --oneline
+}
+
+main

--- a/script/hipify-inplace.sh
+++ b/script/hipify-inplace.sh
@@ -56,7 +56,6 @@ for src in ${hipify_perl_srcs[@]}; do
     ( set -x ; hipify-perl -print-stats -inplace $src ) &> "${log_file}" &
 done
 
-sleep 1 # Hack to make it more likely the echo below prints after the last job command line from above.
 echo "Waiting for hipify jobs to complete"
 wait
 

--- a/script/hipify-inplace.sh
+++ b/script/hipify-inplace.sh
@@ -13,7 +13,10 @@ set -euo pipefail
 
 cd "${DGL_HOME}"
 
-HIPIFY_LOG="/tmp/hipify-inplace.log"
+LOG_DIR="$(mktemp --tmpdir -d hipify-inplace-XXXX)"
+COMBINED_LOG="${LOG_DIR}/hipify-combined.log"
+
+echo "Writing logs to ${LOG_DIR}"
 
 function find_code() {
     find $@ -type f -name '*.cu' -o -name '*.CU'
@@ -35,32 +38,36 @@ declare -a all_srcs=(
     ${hipify_perl_srcs[@]} $(find_code tensoradapter graphbolt)
 )
 
+echo "Starting hipify jobs"
 declare -a log_files=()
 
-log_file="$(mktemp --tmpdir hipify_tensoradapter.XXX.log)"
+log_file="$(mktemp --tmpdir="${LOG_DIR}" hipify_tensoradapter.XXX.log)"
 log_files+=("${log_file}")
-( set -x ; script/hipify-torch-extension.py ${DGL_HOME}/tensoradapter/ &> "${log_file}" ) &
+( set -x ; script/hipify-torch-extension.py ${DGL_HOME}/tensoradapter/ ) &> "${log_file}" &
 
-log_file="$(mktemp --tmpdir hipify_graphbolt.XXX.log)"
+log_file="$(mktemp --tmpdir="${LOG_DIR}" hipify_graphbolt.XXX.log)"
 log_files+=("${log_file}")
-( set -x ; script/hipify-torch-extension.py ${DGL_HOME}/graphbolt/ &> "${log_file}" ) &
+( set -x ; script/hipify-torch-extension.py ${DGL_HOME}/graphbolt/ ) &> "${log_file}" &
 
 
 for src in ${hipify_perl_srcs[@]}; do
-    log_file="$(mktemp --tmpdir hipify_${src//\//_}.XXX.log)"
+    log_file="$(mktemp --tmpdir="${LOG_DIR}" hipify_${src//\//_}.XXX.log)"
     log_files+=("${log_file}")
-    ( set -x ; hipify-perl -print-stats -inplace $src &> "${log_file}" ) &
+    ( set -x ; hipify-perl -print-stats -inplace $src ) &> "${log_file}" &
 done
 
 sleep 1 # Hack to make it more likely the echo below prints after the last job command line from above.
 echo "Waiting for hipify jobs to complete"
 wait
 
-cat "${log_files[@]}" > "${HIPIFY_LOG}" && rm "${log_files[@]}"
-echo "Logs written to ${HIPIFY_LOG}"
+# Using tail will print a separator between each file's contents.
+tail -n +1 "${log_files[@]}" > "${COMBINED_LOG}"
+echo "" >> "${COMBINED_LOG}"
+echo "Combined logs written to ${COMBINED_LOG}"
 
 # Additional fixes for project-specific things and things hipify misses or gets
 # wrong.
+echo "Running additional sed replacements"
 for src in ${all_srcs[@]}; do
     sed -i -f - $src <<-EOF
         s@#include <hipblas.h>@#include <hipblas/hipblas.h>@
@@ -95,7 +102,7 @@ EOF
 
     # If no changes were made, delete the prehip file.
     if cmp -s "${src}" "${src}.prehip"; then
-        echo "Deleting unchanged ${src}.prehip"
+        echo "Deleting unchanged ${src}.prehip" >> "${COMBINED_LOG}"
         rm "${src}.prehip"
     fi
 done


### PR DESCRIPTION
This takes the current working tree and hipifies it, using the resulting working tree to create a "fake" merge commit on the hipified branch (default `hipify-inplace`) merging in the hipified changes but just taking the new changes as given without actually trying to merge the contents.

The idea is that we can use this to populate the `hipify-inplace` convenience branch (probably with a GitHub action eventually).