### PR TITLE
Fix the DGL ROCm backend to pytorch

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -68,4 +68,5 @@ COPY install/conda_env/torch_rocm_pip.txt /install/conda_env/torch_rocm_pip.txt
 RUN ["/bin/bash", "-i", "-c", "conda env create -f /install/conda_env/torch_rocm.yml"]
 RUN ["/bin/bash", "-i", "-c", "pip install --requirement /install/conda_env/non_torch_pip.txt"]
 
-
+# The ROCM backend is only tested for pytorch.
+ENV DGLBACKEND=pytorch


### PR DESCRIPTION
Currently, DGL with ROCm is only tested on pytorch.

Of relevant environment variables, only this one is set, as the environment build doesn't COPY/ADD dgl/, so all other paths aren't known.