### PR TITLE
Change and enable  test_hetero_cached_feature for ROCm

### DIFF
--- a/script/run_rocm_pytests.sh
+++ b/script/run_rocm_pytests.sh
@@ -7,8 +7,7 @@
 
 
 bash ./script/run_pytest.sh -g \
-    tests/python/pytorch \
-    --deselect=tests/python/pytorch/graphbolt/impl/test_hetero_cached_feature.py::test_hetero_cached_feature[gpu_cached_feature]
+    tests/python/pytorch
 
 final_ret=$?
 

--- a/tests/python/pytorch/graphbolt/impl/test_hetero_cached_feature.py
+++ b/tests/python/pytorch/graphbolt/impl/test_hetero_cached_feature.py
@@ -28,7 +28,9 @@ def test_hetero_cached_feature(cached_feature_type):
         )
         for i in range(75)
     }
-    cached_a = cached_feature_type(a, 2**18)
+    # ROCm doesn't support 8bit atomics, so the cache key becomes twice as big.
+    cache_size_bytes = 2**19 if torch.version.hip else 2**18
+    cached_a = cached_feature_type(a, cache_size_bytes)
 
     for i in range(1024):
         etype = i % len(a)


### PR DESCRIPTION
This test was failing because ROCm has to use larger cache keys, resulting in more misses. When using ROCm, the test now uses a larger cache.