### PR TITLE
Revert "[GraphBolt] Enable CXX20. (#7610)"

### DIFF
--- a/graphbolt/src/cnumpy.cc
+++ b/graphbolt/src/cnumpy.cc
@@ -312,7 +312,7 @@ torch::Tensor OnDiskNpyArray::IndexSelectIOUringImpl(torch::Tensor index) {
 
 c10::intrusive_ptr<Future<torch::Tensor>> OnDiskNpyArray::IndexSelectIOUring(
     torch::Tensor index) {
-  return async([=, this] { return IndexSelectIOUringImpl(index); });
+  return async([=] { return IndexSelectIOUringImpl(index); });
 }
 
 #endif  // HAVE_LIBRARY_LIBURING


### PR DESCRIPTION
This was supposedly reverted in 7ea7ccc40, but that actually only reverted the CMAKE_CXX_STANDARD, not the usage of a C++20-only extension.

This was causing compiler warnings.

This reverts commit 0e0046041caec5bee2264ebf97b88928090b84dc.
