### PR TITLE
Use ccache to speed up docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,12 +2,11 @@
 # invalidations. This isn't comprehensive but knocks out a good chunk of
 # potential invalidations and big files.
 
-# Ignores specific to ROCm
-
-# Submodules we don't use
+# Submodules we don't use for ROCm. Since the ROCm image is the only one that
+# uses the repository as context, exclude these.
 third_party/cccl/
 third_party/libxsmm/
-
+third_party/cuco
 
 # We just need the work tree, not the whole git history
 **/*.git/
@@ -26,7 +25,7 @@ notebooks/
 tools/
 tutorials/
 
-# These third_party/ directories dont' affect the build
+# These third_party/ directories don't affect the build
 **/.github/
 **/docs/
 **/examples/

--- a/docker/Dockerfile.rocm-complete
+++ b/docker/Dockerfile.rocm-complete
@@ -12,7 +12,8 @@ FROM gcmn/dgl:rocm-deps-only
 # think this is what we have to do :-/
 
 ARG GPU_TARGETS="${GPU_TARGETS:-gfx908;gfx90a;gfx940;gfx941;gfx942}"
-# ARG is only scoped to this build, so we also declare with ENV
+# ARG is only scoped to this build, so we also declare with ENV. We want users
+# of the image to know what these were set to.
 ENV GPU_TARGETS="${GPU_TARGETS}"
 ENV PYTORCH_ROCM_ARCH="${GPU_TARGETS}"
 ENV AMDGPU_TARGETS="${GPU_TARGETS}"
@@ -24,34 +25,48 @@ WORKDIR "${DGL_HOME}"
 # The person building the image needs to make the context the whole DGL worktree
 # at the commit they're interested in. In the happy path of just checking out
 # the `hipify-inplace` branch and building the image, this is as simple as `.`
-# (note we have build directories and such in the .dockerignore). If you're
-# iterating on the Dockerfile itself though, you probably need to copy the
-# repository somewhere else and use that as the context. I tried various other
-# ways to make this more seamless, but Docker is as usual *almost* good but then
-# falls over.
+# (note we have build directories and such in the .dockerignore). If you are,
+# for instance, iterating on the Dockerfile itself while based on the hip-ready
+# branch though, you probably need to copy the repository somewhere else and use
+# that as the context. I tried various other ways to make this more seamless,
+# but Docker is as usual *almost* good but then falls over.
 COPY . ${DGL_HOME}
 
 # Note that if many HIP architectures are enabled, this build can be very slow,
-# especially the build of graphbolt. To make matters worse, Ninja buffers output
-# from each command, but because DGL is constructed with graphbolt as a
+# especially the build of graphbolt. In particular, it seems to take over 10
+# minutes to compile src/cuda/neighbor_sampler.cu for some reason. Hence it's
+# very much worth it to use caching here. To make matters worse, Ninja buffers
+# output from each command, but because DGL is constructed with graphbolt as a
 # sub-build re-invoking cmake, it is just considered one command by the CMake
 # parent process and thus the whole output gets buffered. This manifests as the
 # image build looking like it's hanging (usually after completing the build of
-# dgl_sparse). We could switch back to plain make. I'm not sure how parallelism
-# is handled in sub-builds though.
-RUN cmake \
+# dgl_sparse). It's a good time for a coffee break. Switching back to make
+# doesn't seem to help much and also makes the build even slower.
+RUN --mount=type=cache,target=/root/.cache/ccache \
+    # We use environment variables rather than CMake defines because they affect
+    # the various sub-builds that DGL spawns without us having to manually
+    # thread that through. And we use `export` rather than `ENV` because we want
+    # to set them for this RUN step, but not spring them upon unwitting users of
+    # image.
+    export CMAKE_C_COMPILER_LAUNCHER=ccache \
+    export CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    export CMAKE_HIP_COMPILER_LAUNCHER=ccache \
+    # The pcg library uses the __TIME__ macro, which always busts the cache,
+    # particularly for that extremely slow neighbor_sampler.cu compilation. We
+    # don't actually care about incorporating the exact time of compilation, so
+    # tell ccache to be sloppy about it.
+    export CCACHE_SLOPPINESS=time_macros \
+    && cmake \
         -DUSE_ROCM=ON \
         -DGPU_TARGETS="${GPU_TARGETS}" \
         -DAMDGPU_TARGETS="${AMDGPU_TARGETS}" \
         -DCMAKE_HIP_ARCHITECTURES="${CMAKE_HIP_ARCHITECTURES}" \
-        -DCMAKE_HIP_FLAGS="-Wno-deprecated -Wno-pass-failed -Werror" \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DROCM_WARN_TOOLCHAIN_VAR=OFF \
         -DCMAKE_C_FLAGS="-Wno-deprecated -Wno-unneeded-internal-declaration -Wno-vla-cxx-extension -Werror" \
         -DCMAKE_CXX_FLAGS="-Wno-deprecated -Wno-unneeded-internal-declaration -Wno-vla-cxx-extension -Werror" \
+        -DCMAKE_HIP_FLAGS="-Wno-deprecated -Wno-pass-failed -Werror" \
         -DCMAKE_INSTALL_PREFIX=build/install \
-        -DCMAKE_C_COMPILER=/usr/bin/clang-19 \
-        -DCMAKE_CXX_COMPILER=/usr/bin/clang++-19 \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_TYPE=release \
         -DBUILD_CPP_TEST=ON \
@@ -62,6 +77,7 @@ RUN cmake \
         -B build \
         -G Ninja \
     && cmake --build build \
+    && ccache -vvv --show-stats \
     && cd python \
     && python setup.py install \
     && python setup.py build_ext --inplace \

--- a/docker/Dockerfile.rocm-deps-only
+++ b/docker/Dockerfile.rocm-deps-only
@@ -63,6 +63,22 @@ RUN wget https://apt.llvm.org/llvm.sh \
 ENV CC=/usr/bin/clang-19
 ENV CXX=/usr/bin/clang++-19
 
+
+# Installing ccache here enables us to use for compiling DGL later. The cache
+# can be persisted in either a `RUN` step or `docker run` via a bind mount
+# (https://docs.docker.com/engine/storage/bind-mounts/). The image already has
+# sccache installed, but it's an ancient version that appears to have no logging
+# capabilities and I was getting cache misses on extremely slow recompiles of
+# DGL. Even installing a newer version, I still had the cache misses and not
+# much indication of what was wrong. With ccache OTOH it took about 5 minutes to
+# debug (the pcg library uses the __TIME__ macro which always busts the cache)
+# and fix (CCACHE_SLOPPINESS=time_macros).
+WORKDIR /ccache
+RUN wget https://github.com/ccache/ccache/releases/download/v4.11.2/ccache-4.11.2-linux-x86_64.tar.xz \
+    && tar -xf ccache-4.11.2-linux-x86_64.tar.xz \
+    && mv ccache-4.11.2-linux-x86_64/ccache /opt/cache/bin/ \
+    && rm -rf /ccache
+
 # Patch ROCM headers with a couple of rocPrim fixes/additions needed by various consumers.
 # ROCm is for DeviceCopy.
 # StreamHPC is for select features.
@@ -87,7 +103,8 @@ RUN apt-get update \
 # https://rocm.docs.amd.com/en/latest/conceptual/cmake-packages.html
 
 ARG GPU_TARGETS="gfx908;gfx90a;gfx940;gfx941;gfx942"
-# ARG is only scoped to this build, so we also declare with ENV
+# ARG is only scoped to this build, so we also declare with ENV. We want users
+# of the image to know what these were set to.
 ENV GPU_TARGETS="${GPU_TARGETS}"
 ENV PYTORCH_ROCM_ARCH="${GPU_TARGETS}"
 ENV AMDGPU_TARGETS="${GPU_TARGETS}"
@@ -95,7 +112,12 @@ ENV CMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}"
 
 # Gather additional or updated ROCm libraries
 WORKDIR /git
-RUN (git clone https://github.com/tpopp/hipCUB.git && cd hipCUB && git checkout f342111197dd020f1c4210b16aa550b08992e97b \
+RUN --mount=type=cache,target=/root/.cache/ccache \
+    export CCACHE_SLOPPINESS=time_macros \
+    export CMAKE_C_COMPILER_LAUNCHER=ccache \
+    export CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    export CMAKE_HIP_COMPILER_LAUNCHER=ccache \
+    && (git clone https://github.com/tpopp/hipCUB.git && cd hipCUB && git checkout f342111197dd020f1c4210b16aa550b08992e97b \
       && mkdir build && cd build \
       && cmake -DGPU_TARGETS="${GPU_TARGETS}" -DAMDGPU_TARGETS="${AMDGPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${CMAKE_HIP_ARCHITECTURES}" -DCMAKE_INSTALL_PREFIX=/opt/rocm .. \
       && make install) \
@@ -112,6 +134,8 @@ RUN (git clone https://github.com/tpopp/hipCUB.git && cd hipCUB && git checkout 
       && cmake -DGPU_TARGETS="${GPU_TARGETS}" -DAMDGPU_TARGETS="${AMDGPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${CMAKE_HIP_ARCHITECTURES}" -DCMAKE_INSTALL_PREFIX=/opt/rocm .. \
       && make install ) \
     && rm -rf /git
+
+WORKDIR /
 
 # The ROCM backend is only tested for pytorch.
 ENV DGLBACKEND=pytorch

--- a/docker/Dockerfile.rocm-deps-only
+++ b/docker/Dockerfile.rocm-deps-only
@@ -15,9 +15,9 @@
 FROM rocm/pytorch:rocm6.3.3_ubuntu22.04_py3.10_pytorch_release_2.4.0
 
 # The rocm/pytorch image already has a conda environment and it has been added
-# to the PATH but not really activated via conda's own mechanisms. This seems to
-# not matter in practice and the image more or less behaves like conda has been
-# activated except that conda itself says that no environment is active. The
+# to the PATH but not really activated via Conda's own mechanisms. This seems to
+# not matter in practice and the image more or less behaves like Conda has been
+# activated except that Conda itself says that no environment is active. The
 # Conda environment is also for some reason owned by the user jenkins, but then
 # the rocm pytorch image has installed some packages as root there, so we have
 # to be root for the rest of the docker build also, even though it makes pip
@@ -64,24 +64,21 @@ ENV CC=/usr/bin/clang-19
 ENV CXX=/usr/bin/clang++-19
 
 
-# Installing ccache here enables us to use for compiling DGL later. The cache
-# can be persisted in either a `RUN` step or `docker run` via a bind mount
-# (https://docs.docker.com/engine/storage/bind-mounts/). The image already has
-# sccache installed, but it's an ancient version that appears to have no logging
-# capabilities and I was getting cache misses on extremely slow recompiles of
-# DGL. Even installing a newer version, I still had the cache misses and not
-# much indication of what was wrong. With ccache OTOH it took about 5 minutes to
-# debug (the pcg library uses the __TIME__ macro which always busts the cache)
-# and fix (CCACHE_SLOPPINESS=time_macros).
+# Installing ccache here enables us to use it for compiling DGL (and other
+# things) later. The cache can be persisted in either a `RUN` step or `docker
+# run` via a bind mount (https://docs.docker.com/engine/storage/bind-mounts/).
+# The image already has sccache installed, but it's an ancient version that
+# wasn't properly caching very slow DGL compile steps. Upgrading to a new
+# version didn't work either, so I switched to ccache.
 WORKDIR /ccache
 RUN wget https://github.com/ccache/ccache/releases/download/v4.11.2/ccache-4.11.2-linux-x86_64.tar.xz \
     && tar -xf ccache-4.11.2-linux-x86_64.tar.xz \
     && mv ccache-4.11.2-linux-x86_64/ccache /opt/cache/bin/ \
     && rm -rf /ccache
 
-# Patch ROCM headers with a couple of rocPrim fixes/additions needed by various consumers.
-# ROCm is for DeviceCopy.
-# StreamHPC is for select features.
+# Patch ROCM headers with a couple of rocPRIM fixes/additions needed by various consumers.
+# - ROCm is for DeviceCopy.
+# - StreamHPC is for device select features.
 WORKDIR /patch-rocm
 RUN apt-get update \
   && apt-get install -y patchutils \
@@ -113,10 +110,17 @@ ENV CMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}"
 # Gather additional or updated ROCm libraries
 WORKDIR /git
 RUN --mount=type=cache,target=/root/.cache/ccache \
-    export CCACHE_SLOPPINESS=time_macros \
+    # We use environment variables rather than CMake defines because they affect
+    # the various sub-builds that DGL spawns without us having to manually
+    # thread that through. And we use `export` rather than `ENV` because we want
+    # to set them for this RUN step, but not spring them upon unwitting users of
+    # image.
     export CMAKE_C_COMPILER_LAUNCHER=ccache \
     export CMAKE_CXX_COMPILER_LAUNCHER=ccache \
     export CMAKE_HIP_COMPILER_LAUNCHER=ccache \
+    # We later compile DGL with this sloppiness setting, so using it here to for
+    # consistency.
+    export CCACHE_SLOPPINESS=time_macros \
     && (git clone https://github.com/tpopp/hipCUB.git && cd hipCUB && git checkout f342111197dd020f1c4210b16aa550b08992e97b \
       && mkdir build && cd build \
       && cmake -DGPU_TARGETS="${GPU_TARGETS}" -DAMDGPU_TARGETS="${AMDGPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${CMAKE_HIP_ARCHITECTURES}" -DCMAKE_INSTALL_PREFIX=/opt/rocm .. \


### PR DESCRIPTION
We can use a cache bind mount to preserve cache data for ccache across
docker build invocations. Then even when the large-granularity docker
build cache is invalidated, we still cache the build of DGL, which is
quite slow.
