### PR TITLE
Make warp size dynamic

### DIFF
--- a/graphbolt/src/cuda/extension/gpu_cache.cu
+++ b/graphbolt/src/cuda/extension/gpu_cache.cu
@@ -26,108 +26,143 @@
 namespace graphbolt {
 namespace cuda {
 
-GpuCache::GpuCache(const std::vector<int64_t> &shape, torch::ScalarType dtype) {
-  TORCH_CHECK(shape.size() >= 2, "Shape must at least have 2 dimensions.");
-  const auto num_items = shape[0];
-  TORCH_CHECK(
-      num_items > 0, "The capacity of GpuCache needs to be a positive.");
-  const int64_t num_feats =
-      std::accumulate(shape.begin() + 1, shape.end(), 1ll, std::multiplies<>());
-  const int element_size =
-      torch::empty(1, torch::TensorOptions().dtype(dtype)).element_size();
-  num_bytes_ = num_feats * element_size;
-  num_float_feats_ = (num_bytes_ + sizeof(float) - 1) / sizeof(float);
-  cache_ = std::make_unique<gpu_cache_t>(
-      (num_items + bucket_size - 1) / bucket_size, num_float_feats_);
-  shape_ = shape;
-  shape_[0] = -1;
-  dtype_ = dtype;
-  device_id_ = cuda::GetCurrentStream().device_index();
-}
+template <int WARP_SIZE>
+class GpuCacheImpl : public GpuCache {
+  using key_t = uint64_t;
+  constexpr static int set_associativity = 2;
+  constexpr static int bucket_size = WARP_SIZE * set_associativity;
+  using gpu_cache_t = ::gpu_cache::gpu_cache<
+      key_t, uint64_t, std::numeric_limits<key_t>::max(), set_associativity,
+      WARP_SIZE>;
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> GpuCache::Query(
-    torch::Tensor keys) {
-  TORCH_CHECK(keys.device().is_cuda(), "Keys should be on a CUDA device.");
-  TORCH_CHECK(
-      keys.device().index() == device_id_,
-      "Keys should be on the correct CUDA device.");
-  TORCH_CHECK(keys.sizes().size() == 1, "Keys should be a 1D tensor.");
-  keys = keys.to(torch::kLong);
-  auto values = torch::empty(
-      {keys.size(0), num_float_feats_}, keys.options().dtype(torch::kFloat));
-  auto missing_index =
-      torch::empty(keys.size(0), keys.options().dtype(torch::kLong));
-  auto missing_keys =
-      torch::empty(keys.size(0), keys.options().dtype(torch::kLong));
-  auto allocator = cuda::GetAllocator();
-  auto missing_len_device = allocator.AllocateStorage<size_t>(1);
-  cache_->Query(
-      reinterpret_cast<const key_t *>(keys.data_ptr()), keys.size(0),
-      values.data_ptr<float>(),
-      reinterpret_cast<uint64_t *>(missing_index.data_ptr()),
-      reinterpret_cast<key_t *>(missing_keys.data_ptr()),
-      missing_len_device.get(), cuda::GetCurrentStream());
-  values = values.view(torch::kByte)
-               .slice(1, 0, num_bytes_)
-               .view(dtype_)
-               .view(shape_);
-  cuda::CopyScalar<size_t> missing_len(missing_len_device.get());
-  missing_index = missing_index.slice(0, 0, static_cast<size_t>(missing_len));
-  missing_keys = missing_keys.slice(0, 0, static_cast<size_t>(missing_len));
-  return std::make_tuple(values, missing_index, missing_keys);
-}
-
-c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> GpuCache::QueryAsync(
-    torch::Tensor keys) {
-  return async(
-      [=] {
-        auto [values, missing_index, missing_keys] = Query(keys);
-        return std::vector{values, missing_index, missing_keys};
-      },
-      true);
-}
-
-void GpuCache::Replace(torch::Tensor keys, torch::Tensor values) {
-  TORCH_CHECK(keys.device().is_cuda(), "Keys should be on a CUDA device.");
-  TORCH_CHECK(
-      keys.device().index() == device_id_,
-      "Keys should be on the correct CUDA device.");
-  TORCH_CHECK(values.device().is_cuda(), "Keys should be on a CUDA device.");
-  TORCH_CHECK(
-      values.device().index() == device_id_,
-      "Values should be on the correct CUDA device.");
-  TORCH_CHECK(
-      keys.size(0) == values.size(0),
-      "The first dimensions of keys and values must match.");
-  TORCH_CHECK(
-      std::equal(shape_.begin() + 1, shape_.end(), values.sizes().begin() + 1),
-      "Values should have the correct dimensions.");
-  TORCH_CHECK(
-      values.scalar_type() == dtype_, "Values should have the correct dtype.");
-  if (keys.numel() == 0) return;
-  keys = keys.to(torch::kLong);
-  torch::Tensor float_values;
-  if (num_bytes_ % sizeof(float) != 0) {
-    float_values = torch::empty(
-        {values.size(0), num_float_feats_},
-        values.options().dtype(torch::kFloat));
-    float_values.view(torch::kByte)
-        .slice(1, 0, num_bytes_)
-        .copy_(values.view(torch::kByte).view({values.size(0), -1}));
-  } else {
-    float_values = values.view(torch::kByte)
-                       .view({values.size(0), -1})
-                       .view(torch::kFloat)
-                       .contiguous();
+ public:
+  GpuCacheImpl(const std::vector<int64_t> &shape, torch::ScalarType dtype) {
+    TORCH_CHECK(shape.size() >= 2, "Shape must at least have 2 dimensions.");
+    const auto num_items = shape[0];
+    TORCH_CHECK(
+        num_items > 0, "The capacity of GpuCache needs to be a positive.");
+    const int64_t num_feats = std::accumulate(
+        shape.begin() + 1, shape.end(), 1ll, std::multiplies<>());
+    const int element_size =
+        torch::empty(1, torch::TensorOptions().dtype(dtype)).element_size();
+    num_bytes_ = num_feats * element_size;
+    num_float_feats_ = (num_bytes_ + sizeof(float) - 1) / sizeof(float);
+    cache_ = std::make_unique<gpu_cache_t>(
+        (num_items + bucket_size - 1) / bucket_size, num_float_feats_);
+    shape_ = shape;
+    shape_[0] = -1;
+    dtype_ = dtype;
+    device_id_ = cuda::GetCurrentStream().device_index();
   }
-  cache_->Replace(
-      reinterpret_cast<const key_t *>(keys.data_ptr()), keys.size(0),
-      float_values.data_ptr<float>(), cuda::GetCurrentStream());
-}
+
+  std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> Query(
+      torch::Tensor keys) {
+    TORCH_CHECK(keys.device().is_cuda(), "Keys should be on a CUDA device.");
+    TORCH_CHECK(
+        keys.device().index() == device_id_,
+        "Keys should be on the correct CUDA device.");
+    TORCH_CHECK(keys.sizes().size() == 1, "Keys should be a 1D tensor.");
+    keys = keys.to(torch::kLong);
+    auto values = torch::empty(
+        {keys.size(0), num_float_feats_}, keys.options().dtype(torch::kFloat));
+    auto missing_index =
+        torch::empty(keys.size(0), keys.options().dtype(torch::kLong));
+    auto missing_keys =
+        torch::empty(keys.size(0), keys.options().dtype(torch::kLong));
+    auto allocator = cuda::GetAllocator();
+    auto missing_len_device = allocator.AllocateStorage<size_t>(1);
+    cache_->Query(
+        reinterpret_cast<const key_t *>(keys.data_ptr()), keys.size(0),
+        values.data_ptr<float>(),
+        reinterpret_cast<uint64_t *>(missing_index.data_ptr()),
+        reinterpret_cast<key_t *>(missing_keys.data_ptr()),
+        missing_len_device.get(), cuda::GetCurrentStream());
+    values = values.view(torch::kByte)
+                 .slice(1, 0, num_bytes_)
+                 .view(dtype_)
+                 .view(shape_);
+    cuda::CopyScalar<size_t> missing_len(missing_len_device.get());
+    missing_index = missing_index.slice(0, 0, static_cast<size_t>(missing_len));
+    missing_keys = missing_keys.slice(0, 0, static_cast<size_t>(missing_len));
+    return std::make_tuple(values, missing_index, missing_keys);
+  }
+
+  c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> QueryAsync(
+      torch::Tensor keys) {
+    return async(
+        [=] {
+          auto [values, missing_index, missing_keys] = Query(keys);
+          return std::vector{values, missing_index, missing_keys};
+        },
+        true);
+  }
+
+  void Replace(torch::Tensor keys, torch::Tensor values) {
+    TORCH_CHECK(keys.device().is_cuda(), "Keys should be on a CUDA device.");
+    TORCH_CHECK(
+        keys.device().index() == device_id_,
+        "Keys should be on the correct CUDA device.");
+    TORCH_CHECK(values.device().is_cuda(), "Keys should be on a CUDA device.");
+    TORCH_CHECK(
+        values.device().index() == device_id_,
+        "Values should be on the correct CUDA device.");
+    TORCH_CHECK(
+        keys.size(0) == values.size(0),
+        "The first dimensions of keys and values must match.");
+    TORCH_CHECK(
+        std::equal(
+            shape_.begin() + 1, shape_.end(), values.sizes().begin() + 1),
+        "Values should have the correct dimensions.");
+    TORCH_CHECK(
+        values.scalar_type() == dtype_,
+        "Values should have the correct dtype.");
+    if (keys.numel() == 0) return;
+    keys = keys.to(torch::kLong);
+    torch::Tensor float_values;
+    if (num_bytes_ % sizeof(float) != 0) {
+      float_values = torch::empty(
+          {values.size(0), num_float_feats_},
+          values.options().dtype(torch::kFloat));
+      float_values.view(torch::kByte)
+          .slice(1, 0, num_bytes_)
+          .copy_(values.view(torch::kByte).view({values.size(0), -1}));
+    } else {
+      float_values = values.view(torch::kByte)
+                         .view({values.size(0), -1})
+                         .view(torch::kFloat)
+                         .contiguous();
+    }
+    cache_->Replace(
+        reinterpret_cast<const key_t *>(keys.data_ptr()), keys.size(0),
+        float_values.data_ptr<float>(), cuda::GetCurrentStream());
+  }
+
+ private:
+  std::vector<int64_t> shape_;
+  torch::ScalarType dtype_;
+  std::unique_ptr<gpu_cache_t> cache_;
+  int64_t num_bytes_;
+  int64_t num_float_feats_;
+  torch::DeviceIndex device_id_;
+};
 
 c10::intrusive_ptr<GpuCache> GpuCache::Create(
     const std::vector<int64_t> &shape, torch::ScalarType dtype) {
-  return c10::make_intrusive<GpuCache>(shape, dtype);
+  int device;
+  CUDA_CALL(hipGetDevice(&device));
+  int warp_size = 0;
+  CUDA_CALL(
+      hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, device));
+
+  switch (warp_size) {
+    case 32:
+      return c10::make_intrusive<GpuCacheImpl<32>>(shape, dtype);
+    case 64:
+      return c10::make_intrusive<GpuCacheImpl<64>>(shape, dtype);
+    default:
+      TORCH_CHECK(
+          false, "Expected warp size to be 32 or 64, but got ", warp_size)
+  }
 }
 
 }  // namespace cuda

--- a/graphbolt/src/cuda/extension/gpu_cache.h
+++ b/graphbolt/src/cuda/extension/gpu_cache.h
@@ -33,54 +33,18 @@ namespace graphbolt {
 namespace cuda {
 
 class GpuCache : public torch::CustomClassHolder {
-  using key_t = long long;
-  constexpr static int set_associativity = 2;
-#ifdef GRAPHBOLT_USE_ROCM
-  constexpr static int WARP_SIZE = 64;
-#else
-  constexpr static int WARP_SIZE = 32;
-#endif
-  constexpr static int bucket_size = WARP_SIZE * set_associativity;
-  using gpu_cache_t = ::gpu_cache::gpu_cache<
-      key_t, uint64_t, std::numeric_limits<key_t>::max(), set_associativity,
-      WARP_SIZE>;
-
  public:
-  /**
-   * @brief Constructor for the GpuCache struct.
-   *
-   * @param shape The shape of the GPU cache.
-   * @param dtype The datatype of items to be stored.
-   */
-  GpuCache(const std::vector<int64_t>& shape, torch::ScalarType dtype);
+  virtual std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> Query(
+      torch::Tensor keys) = 0;
 
-  GpuCache() = default;
+  virtual c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> QueryAsync(
+      torch::Tensor keys) = 0;
 
-  std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> Query(
-      torch::Tensor keys);
-
-  c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> QueryAsync(
-      torch::Tensor keys);
-
-  void Replace(torch::Tensor keys, torch::Tensor values);
+  virtual void Replace(torch::Tensor keys, torch::Tensor values) = 0;
 
   static c10::intrusive_ptr<GpuCache> Create(
       const std::vector<int64_t>& shape, torch::ScalarType dtype);
-
- private:
-  std::vector<int64_t> shape_;
-  torch::ScalarType dtype_;
-  std::unique_ptr<gpu_cache_t> cache_;
-  int64_t num_bytes_;
-  int64_t num_float_feats_;
-  torch::DeviceIndex device_id_;
 };
-
-// The cu file in HugeCTR gpu cache uses unsigned int and long long.
-// Changing to int64_t results in a mismatch of template arguments.
-static_assert(
-    sizeof(long long) == sizeof(int64_t),
-    "long long and int64_t needs to have the same size.");  // NOLINT
 
 }  // namespace cuda
 }  // namespace graphbolt

--- a/src/array/cuda/gather_mm.cu
+++ b/src/array/cuda/gather_mm.cu
@@ -321,7 +321,10 @@ void GatherMM(
   int64_t in_len = A->shape[1];   // cols of A
   const int64_t tot_num_rows = A->shape[0];
   const int ntx = 128;
-  const int nbx = ((tot_num_rows * DGL_WARP_SIZE + ntx - 1) / ntx);
+  int warp_size = 0;
+  CUDA_CALL(hipDeviceGetAttribute(
+      &warp_size, hipDeviceAttributeWarpSize, A->ctx.device_id));
+  const int nbx = ((tot_num_rows * warp_size + ntx - 1) / ntx);
   const dim3 nblks(nbx);
   const dim3 nthrs(ntx);
   CUDA_KERNEL_CALL(
@@ -354,7 +357,10 @@ void GatherMMScatter(
   int64_t in_len = A->shape[1];                                  // cols of A
   int64_t tot_num_rows = A->shape[0];
   const int ntx = 128;
-  const int nbx = ((tot_num_rows * DGL_WARP_SIZE + ntx - 1) / ntx);
+  int warp_size = 0;
+  CUDA_CALL(hipDeviceGetAttribute(
+      &warp_size, hipDeviceAttributeWarpSize, A->ctx.device_id));
+  const int nbx = ((tot_num_rows * warp_size + ntx - 1) / ntx);
   const dim3 nblks(nbx);
   const dim3 nthrs(ntx);
   if (B->ndim == 3) {

--- a/src/array/cuda/segment_reduce.cuh
+++ b/src/array/cuda/segment_reduce.cuh
@@ -81,7 +81,7 @@ __global__ void UpdateGradMinMaxHeteroKernel(
   unsigned int row = warpId;
 
   while (row < n) {
-    for (unsigned int col = laneId; col < dim; col += DGL_WARP_SIZE) {
+    for (unsigned int col = laneId; col < dim; col += warpSize) {
       if (type == idx_type[row * dim + col]) {
         const int write_row = idx[row * dim + col];
         cuda::AtomicAdd(out + write_row * dim + col, feat[row * dim + col]);

--- a/src/array/cuda/spmat_op_impl_csr.cu
+++ b/src/array/cuda/spmat_op_impl_csr.cu
@@ -582,8 +582,7 @@ CSRMatrix CSRSliceMatrix(
   IdArray mask = Full(0, csr.indices->shape[0], nbits, ctx);
   // A count for how many masked values per row.
   IdArray count = NewIdArray(csr.num_rows, ctx, nbits);
-  CUDA_CALL(
-      hipMemset(count.Ptr<IdType>(), 0, sizeof(IdType) * (csr.num_rows)));
+  CUDA_CALL(hipMemset(count.Ptr<IdType>(), 0, sizeof(IdType) * (csr.num_rows)));
 
   // Generate a NodeQueryHashmap buffer. The key of the hashmap is col.
   // For performance, the load factor of the hashmap is in (0.25, 0.5);
@@ -610,18 +609,40 @@ CSRMatrix CSRSliceMatrix(
 
   // Execute SegmentMaskColKernel
   const int64_t num_rows = csr.num_rows;
+
   // With a simple fine-tuning, TILE_SIZE=16 gives a good performance.
   constexpr int TILE_SIZE = 16;
-  constexpr int BLOCK_WARPS = CUDA_MAX_NUM_THREADS / DGL_WARP_SIZE;
   IdType nb =
       dgl::cuda::FindNumBlocks<'x'>((num_rows + TILE_SIZE - 1) / TILE_SIZE);
-  const dim3 nthrs(DGL_WARP_SIZE, BLOCK_WARPS);
   const dim3 nblks(nb);
-  CUDA_KERNEL_CALL(
-      (_SegmentMaskColKernel<IdType, DGL_WARP_SIZE, BLOCK_WARPS, TILE_SIZE>), nblks,
-      nthrs, 0, stream, indptr_data, indices_data, num_rows,
-      hashmap_buffer.Ptr<IdType>(), buffer_size, mask.Ptr<IdType>(),
-      count.Ptr<IdType>());
+  int warp_size = 0;
+  CUDA_CALL(hipDeviceGetAttribute(
+      &warp_size, hipDeviceAttributeWarpSize, ctx.device_id));
+
+  switch (warp_size) {
+    case 32: {
+      constexpr int WARP_SIZE = 32;
+      constexpr int BLOCK_WARPS = CUDA_MAX_NUM_THREADS / WARP_SIZE;
+      const dim3 nthrs(WARP_SIZE, BLOCK_WARPS);
+      CUDA_KERNEL_CALL(
+          (_SegmentMaskColKernel<IdType, WARP_SIZE, BLOCK_WARPS, TILE_SIZE>),
+          nblks, nthrs, 0, stream, indptr_data, indices_data, num_rows,
+          hashmap_buffer.Ptr<IdType>(), buffer_size, mask.Ptr<IdType>(),
+          count.Ptr<IdType>());
+    } break;
+    case 64: {
+      constexpr int WARP_SIZE = 64;
+      constexpr int BLOCK_WARPS = CUDA_MAX_NUM_THREADS / WARP_SIZE;
+      const dim3 nthrs(WARP_SIZE, BLOCK_WARPS);
+      CUDA_KERNEL_CALL(
+          (_SegmentMaskColKernel<IdType, WARP_SIZE, BLOCK_WARPS, TILE_SIZE>),
+          nblks, nthrs, 0, stream, indptr_data, indices_data, num_rows,
+          hashmap_buffer.Ptr<IdType>(), buffer_size, mask.Ptr<IdType>(),
+          count.Ptr<IdType>());
+    } break;
+    default:
+      LOG(FATAL) << "Expected warp size to be 32 or 64 but got " << warp_size;
+  }
 
   IdArray idx = AsNumBits(NonZero(mask), nbits);
   if (idx->shape[0] == 0)

--- a/src/array/cuda/utils.h
+++ b/src/array/cuda/utils.h
@@ -23,6 +23,7 @@ namespace cuda {
 #define CUDA_MAX_NUM_BLOCKS_X 0x7FFFFFFF
 #define CUDA_MAX_NUM_BLOCKS_Y 0xFFFF
 #define CUDA_MAX_NUM_BLOCKS_Z 0xFFFF
+// TODO: I think this is 1024 now?
 // The max number of threads per block
 #define CUDA_MAX_NUM_THREADS 256
 

--- a/src/runtime/cuda/cuda_common.h
+++ b/src/runtime/cuda/cuda_common.h
@@ -17,16 +17,6 @@
 
 #include "../workspace_pool.h"
 
-// TODO: Properly for portable HIP code, this should be determined at runtime,
-// but there's a lot of code that assumes this is a compile-time constant, so
-// for now we're hardcoding it. See
-// https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_cpp_language_extensions.html#warpsize
-#ifdef DGL_USE_ROCM
-#define DGL_WARP_SIZE 64
-#else
-#define DGL_WARP_SIZE 32
-#endif
-
 namespace dgl {
 namespace runtime {
 

--- a/src/runtime/cuda/gpu_cache.cu
+++ b/src/runtime/cuda/gpu_cache.cu
@@ -37,20 +37,26 @@ namespace dgl {
 namespace runtime {
 namespace cuda {
 
-template <typename key_t>
 class GpuCache : public runtime::Object {
+ public:
+  virtual ~GpuCache() = default;
+  virtual std::tuple<NDArray, IdArray, IdArray> Query(IdArray keys) = 0;
+  virtual void Replace(IdArray keys, NDArray values) = 0;
+
+  static constexpr const char *_type_key = "cuda.GpuCache";
+  DGL_DECLARE_OBJECT_TYPE_INFO(GpuCache, Object);
+};
+
+template <typename key_t, int WARP_SIZE>
+class GpuCacheImpl : public GpuCache {
   constexpr static int set_associativity = 2;
-  constexpr static int bucket_size = DGL_WARP_SIZE * set_associativity;
+  constexpr static int bucket_size = WARP_SIZE * set_associativity;
   using gpu_cache_t = gpu_cache::gpu_cache<
       key_t, uint64_t, std::numeric_limits<key_t>::max(), set_associativity,
-      DGL_WARP_SIZE>;
+      WARP_SIZE>;
 
  public:
-  static constexpr const char *_type_key =
-      sizeof(key_t) == 4 ? "cuda.GpuCache32" : "cuda.GpuCache64";
-  DGL_DECLARE_OBJECT_TYPE_INFO(GpuCache, Object);
-
-  GpuCache(size_t num_items, size_t num_feats)
+  GpuCacheImpl(size_t num_items, size_t num_feats)
       : num_feats(num_feats),
         cache(std::make_unique<gpu_cache_t>(
             (num_items + bucket_size - 1) / bucket_size, num_feats)) {
@@ -116,12 +122,7 @@ class GpuCache : public runtime::Object {
   int cuda_device;
 };
 
-static_assert(sizeof(unsigned int) == 4);
-DGL_DEFINE_OBJECT_REF(GpuCacheRef32, GpuCache<unsigned int>);
-// The cu file in HugeCTR gpu cache uses unsigned int and long long.
-// Changing to int64_t results in a mismatch of template arguments.
-static_assert(sizeof(long long) == 8);                      // NOLINT
-DGL_DEFINE_OBJECT_REF(GpuCacheRef64, GpuCache<long long>);  // NOLINT
+DGL_DEFINE_OBJECT_REF(GpuCacheRef, GpuCache);
 
 /* CAPI **********************************************************************/
 
@@ -133,12 +134,27 @@ DGL_REGISTER_GLOBAL("cuda._CAPI_DGLGpuCacheCreate")
       const size_t num_feats = args[1];
       const int num_bits = args[2];
 
-      if (num_bits == 32)
-        *rv = GpuCacheRef32(
-            std::make_shared<GpuCache<unsigned int>>(num_items, num_feats));
+      int device;
+      CUDA_CALL(hipGetDevice(&device))
+      int warp_size = 0;
+      CUDA_CALL(hipDeviceGetAttribute(
+          &warp_size, hipDeviceAttributeWarpSize, device));
+
+      if (num_bits == 32 && warp_size == 32)
+        *rv = GpuCacheRef(
+            std::make_shared<GpuCacheImpl<uint32_t, 32>>(num_items, num_feats));
+      else if (num_bits == 32 && warp_size == 64)
+        *rv = GpuCacheRef(
+            std::make_shared<GpuCacheImpl<uint32_t, 64>>(num_items, num_feats));
+      else if (num_bits == 64 && warp_size == 32)
+        *rv = GpuCacheRef(
+            std::make_shared<GpuCacheImpl<uint64_t, 32>>(num_items, num_feats));
+      else if (num_bits == 64 && warp_size == 64)
+        *rv = GpuCacheRef(
+            std::make_shared<GpuCacheImpl<uint64_t, 64>>(num_items, num_feats));
       else
-        *rv = GpuCacheRef64(std::make_shared<GpuCache<long long>>(  // NOLINT
-            num_items, num_feats));
+        LOG(FATAL) << "Unsupported key size " << num_bits << " and warp size "
+                   << warp_size;
     });
 
 DGL_REGISTER_GLOBAL("cuda._CAPI_DGLGpuCacheQuery")
@@ -146,21 +162,12 @@ DGL_REGISTER_GLOBAL("cuda._CAPI_DGLGpuCacheQuery")
       IdArray keys = args[1];
 
       List<ObjectRef> ret;
-      if (keys->dtype.bits == 32) {
-        GpuCacheRef32 cache = args[0];
-        auto result = cache->Query(keys);
+      GpuCacheRef cache = args[0];
+      auto result = cache->Query(keys);
 
-        ret.push_back(Value(MakeValue(std::get<0>(result))));
-        ret.push_back(Value(MakeValue(std::get<1>(result))));
-        ret.push_back(Value(MakeValue(std::get<2>(result))));
-      } else {
-        GpuCacheRef64 cache = args[0];
-        auto result = cache->Query(keys);
-
-        ret.push_back(Value(MakeValue(std::get<0>(result))));
-        ret.push_back(Value(MakeValue(std::get<1>(result))));
-        ret.push_back(Value(MakeValue(std::get<2>(result))));
-      }
+      ret.push_back(Value(MakeValue(std::get<0>(result))));
+      ret.push_back(Value(MakeValue(std::get<1>(result))));
+      ret.push_back(Value(MakeValue(std::get<2>(result))));
 
       *rv = ret;
     });
@@ -170,13 +177,8 @@ DGL_REGISTER_GLOBAL("cuda._CAPI_DGLGpuCacheReplace")
       IdArray keys = args[1];
       NDArray values = args[2];
 
-      if (keys->dtype.bits == 32) {
-        GpuCacheRef32 cache = args[0];
-        cache->Replace(keys, values);
-      } else {
-        GpuCacheRef64 cache = args[0];
-        cache->Replace(keys, values);
-      }
+      GpuCacheRef cache = args[0];
+      cache->Replace(keys, values);
 
       *rv = List<ObjectRef>{};
     });

--- a/third_party/HugeCTR/gpu_cache/include/nv_gpu_cache.hpp
+++ b/third_party/HugeCTR/gpu_cache/include/nv_gpu_cache.hpp
@@ -28,16 +28,6 @@
 #endif
 
 #define SET_ASSOCIATIVITY 2
-// TODO: Properly for portable HIP code, this should be determined at runtime,
-// but there's a lot of code that assumes this is a compile-time constant, so
-// for now we're hardcoding it. See
-// https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_cpp_language_extensions.html#warpsize
-#ifdef DGL_USE_ROCM
-#define SLAB_SIZE 64
-#else
-#define SLAB_SIZE 32
-#endif
-#define TASK_PER_WARP_TILE_MACRO 1
 
 namespace gpu_cache {
 

--- a/third_party/HugeCTR/gpu_cache/src/nv_gpu_cache.cu
+++ b/third_party/HugeCTR/gpu_cache/src/nv_gpu_cache.cu
@@ -1263,14 +1263,20 @@ gpu_cache<key_type, ref_counter_type, empty_key, set_associativity, warp_size, s
     printf("Error: Invalid value for set_associativity.\n");
     return;
   }
-  // Power of 2 between 1 and SLAB_SIZE
-  if ((warp_size & (warp_size-1)) != 0 || warp_size < 1 || warp_size > SLAB_SIZE) {
-    printf("Error: Invalid value for warp_size %d.\n", warp_size);
-    return;
-  }
 
   // Get the current CUDA dev
   CUDA_CHECK(hipGetDevice(&dev_));
+
+  int threads_per_warp = 0;
+  CUDA_CHECK(hipDeviceGetAttribute(
+      &threads_per_warp, hipDeviceAttributeWarpSize, dev_));
+
+  // Power of 2 between 1 and threads per warp
+  if ((warp_size & (warp_size - 1)) != 0 || warp_size < 1 ||
+      warp_size > threads_per_warp) {
+    printf("Error: Invalid value for warp_size %d.\n", warp_size);
+    return;
+  }
 
   // Calculate # of slot
   num_slot_ = capacity_in_set_ * set_associativity * warp_size;
@@ -1311,14 +1317,20 @@ gpu_cache<key_type, ref_counter_type, empty_key, set_associativity, warp_size, s
     printf("Error: Invalid value for set_associativity.\n");
     return;
   }
-  // Power of 2 between 1 and SLAB_SIZE
-  if ((warp_size & (warp_size-1)) != 0 || warp_size < 1 || warp_size > SLAB_SIZE) {
-    printf("Error: Invalid value for warp_size %d.\n", warp_size);
-    return;
-  }
 
   // Get the current CUDA dev
   CUDA_CHECK(hipGetDevice(&dev_));
+
+  int threads_per_warp = 0;
+  CUDA_CHECK(hipDeviceGetAttribute(
+      &threads_per_warp, hipDeviceAttributeWarpSize, dev_));
+
+  // Power of 2 between 1 and threads per warp
+  if ((warp_size & (warp_size - 1)) != 0 || warp_size < 1 ||
+      warp_size > threads_per_warp) {
+    printf("Error: Invalid value for warp_size %d.\n", warp_size);
+    return;
+  }
 
   // Calculate # of slot
   num_slot_ = capacity_in_set_ * set_associativity * warp_size;
@@ -1655,8 +1667,16 @@ void gpu_cache<key_type, ref_counter_type, empty_key, set_associativity, warp_si
 }
 #endif
 
-template class gpu_cache<unsigned int, uint64_t, std::numeric_limits<unsigned int>::max(),
-                         SET_ASSOCIATIVITY, SLAB_SIZE>;
-template class gpu_cache<long long, uint64_t, std::numeric_limits<long long>::max(),
-                         SET_ASSOCIATIVITY, SLAB_SIZE>;
+template class gpu_cache<
+    uint32_t, uint64_t, std::numeric_limits<uint32_t>::max(), SET_ASSOCIATIVITY,
+    32>;
+template class gpu_cache<
+    uint64_t, uint64_t, std::numeric_limits<uint64_t>::max(), SET_ASSOCIATIVITY,
+    32>;
+template class gpu_cache<
+    uint32_t, uint64_t, std::numeric_limits<uint32_t>::max(), SET_ASSOCIATIVITY,
+    64>;
+template class gpu_cache<
+    uint64_t, uint64_t, std::numeric_limits<uint64_t>::max(), SET_ASSOCIATIVITY,
+    64>;
 }  // namespace gpu_cache

--- a/third_party/HugeCTR/gpu_cache/src/nv_gpu_cache.cu
+++ b/third_party/HugeCTR/gpu_cache/src/nv_gpu_cache.cu
@@ -261,140 +261,143 @@ __global__ void get_kernel(const key_type* d_keys, const size_t len, float* d_va
                            ref_counter_type* slot_counter, const size_t capacity_in_set,
                            const slabset* keys, const float* vals, mutex* set_mutex,
                            const size_t task_per_warp_tile) {
-  // Lane(thread) ID within a warp_tile
-  cg::thread_block_tile<warp_size> warp_tile =
-      cg::tiled_partition<warp_size>(cg::this_thread_block());
-  const size_t lane_idx = warp_tile.thread_rank();
-  // Warp tile global ID
-  const size_t warp_tile_global_idx =
-      (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
-  // The index of key for this thread
-  const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
-  // The assigned key for this lane(thread)
-  key_type key;
-  // The dst slabset and the dst slab inside this set
-  size_t src_set;
-  size_t src_slab;
-  // The variable that contains the missing key
-  key_type missing_key;
-  // The variable that contains the index for the missing key
-  uint64_t missing_index;
-  // The counter for counting the missing key in this warp
-  uint8_t warp_missing_counter = 0;
-  // Active flag: whether current lane(thread) has unfinished task
-  bool active = false;
-  if (lane_idx < task_per_warp_tile) {
-    if (key_idx < len) {
-      active = true;
-      key = d_keys[key_idx];
-      src_set = set_hasher::hash(key) % capacity_in_set;
-      src_slab = slab_hasher::hash(key) % set_associativity;
-    }
-  }
-
-  // Lane participate in warp_tile ballot to produce warp-level work queue
-  unsigned active_mask = warp_tile.ballot(active);
-
-  // The warp-level outer loop: finish all the tasks within the work queue
-  while (active_mask != 0) {
-    // Next task in the work quere, start from lower index lane(thread)
-    int next_lane = __ffs(active_mask) - 1;
-    // Broadcast the task and the global index to all lane in the warp_tile
-    key_type next_key = warp_tile.shfl(key, next_lane);
-    size_t next_idx = warp_tile.shfl(key_idx, next_lane);
-    size_t next_set = warp_tile.shfl(src_set, next_lane);
-    size_t next_slab = warp_tile.shfl(src_slab, next_lane);
-
-    // Counter to record how many slab have been searched
-    size_t counter = 0;
-
-    // Working queue before task started
-    const unsigned old_active_mask = active_mask;
-
-    // Lock the slabset before operating the slabset
-    warp_lock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
-
-    // The warp-level inner loop: finish a single task in the work queue
-    while (active_mask == old_active_mask) {
-      // When all the slabs inside a slabset have been searched, mark missing task, task is
-      // completed
-      if (counter >= set_associativity) {
-        if (lane_idx == warp_missing_counter) {
-          missing_key = next_key;
-          missing_index = next_idx;
-        }
-
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        warp_missing_counter++;
-        active_mask = warp_tile.ballot(active);
-        break;
+  assert(warp_size <= warpSize);
+  if constexpr (warp_size <= warpSize) {
+    // Lane(thread) ID within a warp_tile
+    cg::thread_block_tile<warp_size> warp_tile =
+        cg::tiled_partition<warp_size>(cg::this_thread_block());
+    const size_t lane_idx = warp_tile.thread_rank();
+    // Warp tile global ID
+    const size_t warp_tile_global_idx =
+        (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
+    // The index of key for this thread
+    const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
+    // The assigned key for this lane(thread)
+    key_type key;
+    // The dst slabset and the dst slab inside this set
+    size_t src_set;
+    size_t src_slab;
+    // The variable that contains the missing key
+    key_type missing_key;
+    // The variable that contains the index for the missing key
+    uint64_t missing_index;
+    // The counter for counting the missing key in this warp
+    uint8_t warp_missing_counter = 0;
+    // Active flag: whether current lane(thread) has unfinished task
+    bool active = false;
+    if (lane_idx < task_per_warp_tile) {
+      if (key_idx < len) {
+        active = true;
+        key = d_keys[key_idx];
+        src_set = set_hasher::hash(key) % capacity_in_set;
+        src_slab = slab_hasher::hash(key) % set_associativity;
       }
-
-      // The warp_tile read out the slab
-      key_type read_key = keys[next_set].set_[next_slab].slab_[lane_idx];
-
-      // Compare the slab data with the target key
-      int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
-
-      // If found, mark hit task, copy the founded data, the task is completed
-      if (found_lane >= 0) {
-        size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
-        if (lane_idx == (size_t)next_lane) {
-          slot_counter[found_offset] = global_counter->load(cuda::std::memory_order_relaxed);
-          active = false;
-        }
-
-        warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
-                                  d_values + next_idx * embedding_vec_size,
-                                  vals + found_offset * embedding_vec_size);
-
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // Compare the slab data with empty key, if found empty key, mark missing task, task is
-      // completed
-      if (warp_tile.ballot(read_key == empty_key) != 0) {
-        if (lane_idx == warp_missing_counter) {
-          missing_key = next_key;
-          missing_index = next_idx;
-        }
-
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        warp_missing_counter++;
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // Not found in this slab, the task is not completed, goto searching next slab
-      counter++;
-      next_slab = (next_slab + 1) % set_associativity;
     }
 
-    // Unlock the slabset after operating the slabset
-    warp_unlock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
-  }
+    // Lane participate in warp_tile ballot to produce warp-level work queue
+    unsigned active_mask = warp_tile.ballot(active);
 
-  // After warp_tile complete the working queue, save the result for output
-  // First thread of the warp_tile accumulate the missing length to global variable
-  // TODO(nod-ai/dgl#14): clang miscompiles if this isn't initialized even
-  // though the shfl instructions are marked with maybe_undef. Figure out
-  // whether this is indeed a clang bug and remove this initialization.
-  size_t warp_position = 0;
-  if (lane_idx == 0) {
-    warp_position = atomicAdd(d_missing_len, (size_t)warp_missing_counter);
-  }
-  warp_position = warp_tile.shfl(warp_position, 0);
+    // The warp-level outer loop: finish all the tasks within the work queue
+    while (active_mask != 0) {
+      // Next task in the work quere, start from lower index lane(thread)
+      int next_lane = __ffs(active_mask) - 1;
+      // Broadcast the task and the global index to all lane in the warp_tile
+      key_type next_key = warp_tile.shfl(key, next_lane);
+      size_t next_idx = warp_tile.shfl(key_idx, next_lane);
+      size_t next_set = warp_tile.shfl(src_set, next_lane);
+      size_t next_slab = warp_tile.shfl(src_slab, next_lane);
 
-  if (lane_idx < warp_missing_counter) {
-    d_missing_keys[warp_position + lane_idx] = missing_key;
-    d_missing_index[warp_position + lane_idx] = missing_index;
+      // Counter to record how many slab have been searched
+      size_t counter = 0;
+
+      // Working queue before task started
+      const unsigned old_active_mask = active_mask;
+
+      // Lock the slabset before operating the slabset
+      warp_lock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
+
+      // The warp-level inner loop: finish a single task in the work queue
+      while (active_mask == old_active_mask) {
+        // When all the slabs inside a slabset have been searched, mark missing task, task is
+        // completed
+        if (counter >= set_associativity) {
+          if (lane_idx == warp_missing_counter) {
+            missing_key = next_key;
+            missing_index = next_idx;
+          }
+
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          warp_missing_counter++;
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // The warp_tile read out the slab
+        key_type read_key = keys[next_set].set_[next_slab].slab_[lane_idx];
+
+        // Compare the slab data with the target key
+        int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
+
+        // If found, mark hit task, copy the founded data, the task is completed
+        if (found_lane >= 0) {
+          size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
+          if (lane_idx == (size_t)next_lane) {
+            slot_counter[found_offset] = global_counter->load(cuda::std::memory_order_relaxed);
+            active = false;
+          }
+
+          warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
+                                    d_values + next_idx * embedding_vec_size,
+                                    vals + found_offset * embedding_vec_size);
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // Compare the slab data with empty key, if found empty key, mark missing task, task is
+        // completed
+        if (warp_tile.ballot(read_key == empty_key) != 0) {
+          if (lane_idx == warp_missing_counter) {
+            missing_key = next_key;
+            missing_index = next_idx;
+          }
+
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          warp_missing_counter++;
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // Not found in this slab, the task is not completed, goto searching next slab
+        counter++;
+        next_slab = (next_slab + 1) % set_associativity;
+      }
+
+      // Unlock the slabset after operating the slabset
+      warp_unlock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
+    }
+
+    // After warp_tile complete the working queue, save the result for output
+    // First thread of the warp_tile accumulate the missing length to global variable
+    // TODO(nod-ai/dgl#14): clang miscompiles if this isn't initialized even
+    // though the shfl instructions are marked with maybe_undef. Figure out
+    // whether this is indeed a clang bug and remove this initialization.
+    size_t warp_position = 0;
+    if (lane_idx == 0) {
+      warp_position = atomicAdd(d_missing_len, (size_t)warp_missing_counter);
+    }
+    warp_position = warp_tile.shfl(warp_position, 0);
+
+    if (lane_idx < warp_missing_counter) {
+      d_missing_keys[warp_position + lane_idx] = missing_key;
+      d_missing_index[warp_position + lane_idx] = missing_index;
+    }
   }
 }
 #else
@@ -409,141 +412,144 @@ __global__ void get_kernel(const key_type* d_keys, const size_t len, float* d_va
                            volatile ref_counter_type* slot_counter, const size_t capacity_in_set,
                            volatile slabset* keys, volatile float* vals, volatile int* set_mutex,
                            const size_t task_per_warp_tile) {
-  // Lane(thread) ID within a warp_tile
-  cg::thread_block_tile<warp_size> warp_tile =
-      cg::tiled_partition<warp_size>(cg::this_thread_block());
-  const size_t lane_idx = warp_tile.thread_rank();
-  // Warp tile global ID
-  const size_t warp_tile_global_idx =
-      (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
-  // The index of key for this thread
-  const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
-  // The assigned key for this lane(thread)
-  key_type key;
-  // The dst slabset and the dst slab inside this set
-  size_t src_set;
-  size_t src_slab;
-  // The variable that contains the missing key
-  key_type missing_key;
-  // The variable that contains the index for the missing key
-  uint64_t missing_index;
-  // The counter for counting the missing key in this warp
-  uint8_t warp_missing_counter = 0;
-  // Active flag: whether current lane(thread) has unfinished task
-  bool active = false;
-  if (lane_idx < task_per_warp_tile) {
-    if (key_idx < len) {
-      active = true;
-      key = d_keys[key_idx];
-      src_set = set_hasher::hash(key) % capacity_in_set;
-      src_slab = slab_hasher::hash(key) % set_associativity;
-    }
-  }
-
-  // Lane participate in warp_tile ballot to produce warp-level work queue
-  unsigned active_mask = warp_tile.ballot(active);
-
-  // The warp-level outer loop: finish all the tasks within the work queue
-  while (active_mask != 0) {
-    // Next task in the work quere, start from lower index lane(thread)
-    int next_lane = __ffs(active_mask) - 1;
-    // Broadcast the task and the global index to all lane in the warp_tile
-    key_type next_key = warp_tile.shfl(key, next_lane);
-    size_t next_idx = warp_tile.shfl(key_idx, next_lane);
-    size_t next_set = warp_tile.shfl(src_set, next_lane);
-    size_t next_slab = warp_tile.shfl(src_slab, next_lane);
-
-    // Counter to record how many slab have been searched
-    size_t counter = 0;
-
-    // Working queue before task started
-    const unsigned old_active_mask = active_mask;
-
-    // Lock the slabset before operating the slabset
-    warp_lock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
-
-    // The warp-level inner loop: finish a single task in the work queue
-    while (active_mask == old_active_mask) {
-      // When all the slabs inside a slabset have been searched, mark missing task, task is
-      // completed
-      if (counter >= set_associativity) {
-        if (lane_idx == warp_missing_counter) {
-          missing_key = next_key;
-          missing_index = next_idx;
-        }
-
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        warp_missing_counter++;
-        active_mask = warp_tile.ballot(active);
-        break;
+  assert(warp_size <= warpSize);
+  if constexpr (warp_size <= warpSize) {
+    // Lane(thread) ID within a warp_tile
+    cg::thread_block_tile<warp_size> warp_tile =
+        cg::tiled_partition<warp_size>(cg::this_thread_block());
+    const size_t lane_idx = warp_tile.thread_rank();
+    // Warp tile global ID
+    const size_t warp_tile_global_idx =
+        (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
+    // The index of key for this thread
+    const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
+    // The assigned key for this lane(thread)
+    key_type key;
+    // The dst slabset and the dst slab inside this set
+    size_t src_set;
+    size_t src_slab;
+    // The variable that contains the missing key
+    key_type missing_key;
+    // The variable that contains the index for the missing key
+    uint64_t missing_index;
+    // The counter for counting the missing key in this warp
+    uint8_t warp_missing_counter = 0;
+    // Active flag: whether current lane(thread) has unfinished task
+    bool active = false;
+    if (lane_idx < task_per_warp_tile) {
+      if (key_idx < len) {
+        active = true;
+        key = d_keys[key_idx];
+        src_set = set_hasher::hash(key) % capacity_in_set;
+        src_slab = slab_hasher::hash(key) % set_associativity;
       }
-
-      // The warp_tile read out the slab
-      key_type read_key = ((volatile key_type*)(keys[next_set].set_[next_slab].slab_))[lane_idx];
-
-      // Compare the slab data with the target key
-      int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
-
-      // If found, mark hit task, copy the founded data, the task is completed
-      if (found_lane >= 0) {
-        size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
-        if (lane_idx == (size_t)next_lane) {
-          slot_counter[found_offset] = atomicAdd(global_counter, 0);
-          active = false;
-        }
-
-        warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
-                                  (volatile float*)(d_values + next_idx * embedding_vec_size),
-                                  (volatile float*)(vals + found_offset * embedding_vec_size));
-
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // Compare the slab data with empty key, if found empty key, mark missing task, task is
-      // completed
-      if (warp_tile.ballot(read_key == empty_key) != 0) {
-        if (lane_idx == warp_missing_counter) {
-          missing_key = next_key;
-          missing_index = next_idx;
-        }
-
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        warp_missing_counter++;
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // Not found in this slab, the task is not completed, goto searching next slab
-      counter++;
-      next_slab = (next_slab + 1) % set_associativity;
     }
 
-    // Unlock the slabset after operating the slabset
-    warp_unlock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
-  }
+    // Lane participate in warp_tile ballot to produce warp-level work queue
+    unsigned active_mask = warp_tile.ballot(active);
 
-  // After warp_tile complete the working queue, save the result for output
-  // First thread of the warp_tile accumulate the missing length to global
-  // variable.
-  // TODO(nod-ai/dgl#14): clang miscompiles if this isn't initialized even
-  // though the shfl instructions are marked with maybe_undef. Figure out
-  // whether this is indeed a clang bug and remove this initialization.
-  size_t warp_position = 0;
-  if (lane_idx == 0) {
-    warp_position = atomicAdd(d_missing_len, (size_t)warp_missing_counter);
-  }
-  warp_position = warp_tile.shfl(warp_position, 0);
+    // The warp-level outer loop: finish all the tasks within the work queue
+    while (active_mask != 0) {
+      // Next task in the work quere, start from lower index lane(thread)
+      int next_lane = __ffs(active_mask) - 1;
+      // Broadcast the task and the global index to all lane in the warp_tile
+      key_type next_key = warp_tile.shfl(key, next_lane);
+      size_t next_idx = warp_tile.shfl(key_idx, next_lane);
+      size_t next_set = warp_tile.shfl(src_set, next_lane);
+      size_t next_slab = warp_tile.shfl(src_slab, next_lane);
 
-  if (lane_idx < warp_missing_counter) {
-    d_missing_keys[warp_position + lane_idx] = missing_key;
-    d_missing_index[warp_position + lane_idx] = missing_index;
+      // Counter to record how many slab have been searched
+      size_t counter = 0;
+
+      // Working queue before task started
+      const unsigned old_active_mask = active_mask;
+
+      // Lock the slabset before operating the slabset
+      warp_lock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
+
+      // The warp-level inner loop: finish a single task in the work queue
+      while (active_mask == old_active_mask) {
+        // When all the slabs inside a slabset have been searched, mark missing task, task is
+        // completed
+        if (counter >= set_associativity) {
+          if (lane_idx == warp_missing_counter) {
+            missing_key = next_key;
+            missing_index = next_idx;
+          }
+
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          warp_missing_counter++;
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // The warp_tile read out the slab
+        key_type read_key = ((volatile key_type*)(keys[next_set].set_[next_slab].slab_))[lane_idx];
+
+        // Compare the slab data with the target key
+        int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
+
+        // If found, mark hit task, copy the founded data, the task is completed
+        if (found_lane >= 0) {
+          size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
+          if (lane_idx == (size_t)next_lane) {
+            slot_counter[found_offset] = atomicAdd(global_counter, 0);
+            active = false;
+          }
+
+          warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
+                                    (volatile float*)(d_values + next_idx * embedding_vec_size),
+                                    (volatile float*)(vals + found_offset * embedding_vec_size));
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // Compare the slab data with empty key, if found empty key, mark missing task, task is
+        // completed
+        if (warp_tile.ballot(read_key == empty_key) != 0) {
+          if (lane_idx == warp_missing_counter) {
+            missing_key = next_key;
+            missing_index = next_idx;
+          }
+
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          warp_missing_counter++;
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // Not found in this slab, the task is not completed, goto searching next slab
+        counter++;
+        next_slab = (next_slab + 1) % set_associativity;
+      }
+
+      // Unlock the slabset after operating the slabset
+      warp_unlock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
+    }
+
+    // After warp_tile complete the working queue, save the result for output
+    // First thread of the warp_tile accumulate the missing length to global
+    // variable.
+    // TODO(nod-ai/dgl#14): clang miscompiles if this isn't initialized even
+    // though the shfl instructions are marked with maybe_undef. Figure out
+    // whether this is indeed a clang bug and remove this initialization.
+    size_t warp_position = 0;
+    if (lane_idx == 0) {
+      warp_position = atomicAdd(d_missing_len, (size_t)warp_missing_counter);
+    }
+    warp_position = warp_tile.shfl(warp_position, 0);
+
+    if (lane_idx < warp_missing_counter) {
+      d_missing_keys[warp_position + lane_idx] = missing_key;
+      d_missing_index[warp_position + lane_idx] = missing_index;
+    }
   }
 }
 #endif
@@ -562,150 +568,153 @@ __global__ void insert_replace_kernel(const key_type* d_keys, const float* d_val
                                       const atomic_ref_counter_type* global_counter,
                                       const size_t capacity_in_set,
                                       const size_t task_per_warp_tile) {
-  // Lane(thread) ID within a warp_tile
-  cg::thread_block_tile<warp_size> warp_tile =
-      cg::tiled_partition<warp_size>(cg::this_thread_block());
-  const size_t lane_idx = warp_tile.thread_rank();
-  // Warp tile global ID
-  const size_t warp_tile_global_idx =
-      (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
-  // The index of key for this thread
-  const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
-  // The assigned key for this lane(thread)
-  key_type key;
-  // The dst slabset and the dst slab inside this set
-  size_t src_set;
-  size_t src_slab;
-  // Active flag: whether current lane(thread) has unfinished task
-  bool active = false;
-  if (lane_idx < task_per_warp_tile) {
-    if (key_idx < len) {
-      active = true;
-      key = d_keys[key_idx];
-      src_set = set_hasher::hash(key) % capacity_in_set;
-      src_slab = slab_hasher::hash(key) % set_associativity;
-    }
-  }
-
-  // Lane participate in warp_tile ballot to produce warp-level work queue
-  unsigned active_mask = warp_tile.ballot(active);
-
-  // The warp-level outer loop: finish all the tasks within the work queue
-  while (active_mask != 0) {
-    // Next task in the work quere, start from lower index lane(thread)
-    int next_lane = __ffs(active_mask) - 1;
-    // Broadcast the task, the global index and the src slabset and slab to all lane in a warp_tile
-    key_type next_key = warp_tile.shfl(key, next_lane);
-    size_t next_idx = warp_tile.shfl(key_idx, next_lane);
-    size_t next_set = warp_tile.shfl(src_set, next_lane);
-    size_t next_slab = warp_tile.shfl(src_slab, next_lane);
-    size_t first_slab = next_slab;
-
-    // Counter to record how many slab have been searched
-    size_t counter = 0;
-
-    // Variable to keep the min slot counter during the probing
-    ref_counter_type min_slot_counter_val = max_ref_counter_type;
-    // Variable to keep the slab distance for slot with min counter
-    size_t slab_distance = max_slab_distance;
-    // Variable to keep the slot distance for slot with min counter within the slab
-    size_t slot_distance;
-    // Working queue before task started
-    const unsigned old_active_mask = active_mask;
-
-    // Lock the slabset before operating the slabset
-    warp_lock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
-
-    // The warp-level inner loop: finish a single task in the work queue
-    while (active_mask == old_active_mask) {
-      // When all the slabs inside a slabset have been searched
-      // and no empty slots or target slots are found. Replace with LRU
-      if (counter >= set_associativity) {
-        // (sub)Warp all-reduction, the reduction result store in all threads
-        warp_min_reduction<ref_counter_type, warp_size>(warp_tile, min_slot_counter_val,
-                                                        slab_distance, slot_distance);
-
-        // Calculate the position of LR slot
-        size_t target_slab = (first_slab + slab_distance) % set_associativity;
-        size_t slot_index =
-            (next_set * set_associativity + target_slab) * warp_size + slot_distance;
-
-        // Replace the LR slot
-        if (lane_idx == (size_t)next_lane) {
-          keys[next_set].set_[target_slab].slab_[slot_distance] = key;
-          slot_counter[slot_index] = global_counter->load(cuda::std::memory_order_relaxed);
-        }
-
-        warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
-                                  vals + slot_index * embedding_vec_size,
-                                  d_values + next_idx * embedding_vec_size);
-
-        // Replace complete, mark this task completed
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        active_mask = warp_tile.ballot(active);
-        break;
+  assert(warp_size <= warpSize);
+  if constexpr (warp_size <= warpSize) {
+    // Lane(thread) ID within a warp_tile
+    cg::thread_block_tile<warp_size> warp_tile =
+        cg::tiled_partition<warp_size>(cg::this_thread_block());
+    const size_t lane_idx = warp_tile.thread_rank();
+    // Warp tile global ID
+    const size_t warp_tile_global_idx =
+        (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
+    // The index of key for this thread
+    const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
+    // The assigned key for this lane(thread)
+    key_type key;
+    // The dst slabset and the dst slab inside this set
+    size_t src_set;
+    size_t src_slab;
+    // Active flag: whether current lane(thread) has unfinished task
+    bool active = false;
+    if (lane_idx < task_per_warp_tile) {
+      if (key_idx < len) {
+        active = true;
+        key = d_keys[key_idx];
+        src_set = set_hasher::hash(key) % capacity_in_set;
+        src_slab = slab_hasher::hash(key) % set_associativity;
       }
-
-      // The warp_tile read out the slab
-      key_type read_key = keys[next_set].set_[next_slab].slab_[lane_idx];
-
-      // Compare the slab data with the target key
-      int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
-
-      // If found target key, the insertion/replace is no longer needed.
-      // Refresh the slot, the task is completed
-      if (found_lane >= 0) {
-        size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
-        if (lane_idx == (size_t)next_lane) {
-          slot_counter[found_offset] = global_counter->load(cuda::std::memory_order_relaxed);
-          active = false;
-        }
-
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // Compare the slab data with empty key.
-      // If found empty key, do insertion,the task is complete
-      found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == empty_key))) - 1;
-      if (found_lane >= 0) {
-        size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
-
-        if (lane_idx == (size_t)next_lane) {
-          keys[next_set].set_[next_slab].slab_[found_lane] = key;
-          slot_counter[found_offset] = global_counter->load(cuda::std::memory_order_relaxed);
-        }
-
-        warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
-                                  vals + found_offset * embedding_vec_size,
-                                  d_values + next_idx * embedding_vec_size);
-
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // If no target or unused slot found in this slab,
-      // Refresh LR info, continue probing
-      ref_counter_type read_slot_counter =
-          slot_counter[(next_set * set_associativity + next_slab) * warp_size + lane_idx];
-      if (read_slot_counter < min_slot_counter_val) {
-        min_slot_counter_val = read_slot_counter;
-        slab_distance = counter;
-      }
-
-      counter++;
-      next_slab = (next_slab + 1) % set_associativity;
     }
 
-    // Unlock the slabset after operating the slabset
-    warp_unlock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
+    // Lane participate in warp_tile ballot to produce warp-level work queue
+    unsigned active_mask = warp_tile.ballot(active);
+
+    // The warp-level outer loop: finish all the tasks within the work queue
+    while (active_mask != 0) {
+      // Next task in the work quere, start from lower index lane(thread)
+      int next_lane = __ffs(active_mask) - 1;
+      // Broadcast the task, the global index and the src slabset and slab to all lane in a warp_tile
+      key_type next_key = warp_tile.shfl(key, next_lane);
+      size_t next_idx = warp_tile.shfl(key_idx, next_lane);
+      size_t next_set = warp_tile.shfl(src_set, next_lane);
+      size_t next_slab = warp_tile.shfl(src_slab, next_lane);
+      size_t first_slab = next_slab;
+
+      // Counter to record how many slab have been searched
+      size_t counter = 0;
+
+      // Variable to keep the min slot counter during the probing
+      ref_counter_type min_slot_counter_val = max_ref_counter_type;
+      // Variable to keep the slab distance for slot with min counter
+      size_t slab_distance = max_slab_distance;
+      // Variable to keep the slot distance for slot with min counter within the slab
+      size_t slot_distance;
+      // Working queue before task started
+      const unsigned old_active_mask = active_mask;
+
+      // Lock the slabset before operating the slabset
+      warp_lock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
+
+      // The warp-level inner loop: finish a single task in the work queue
+      while (active_mask == old_active_mask) {
+        // When all the slabs inside a slabset have been searched
+        // and no empty slots or target slots are found. Replace with LRU
+        if (counter >= set_associativity) {
+          // (sub)Warp all-reduction, the reduction result store in all threads
+          warp_min_reduction<ref_counter_type, warp_size>(warp_tile, min_slot_counter_val,
+                                                          slab_distance, slot_distance);
+
+          // Calculate the position of LR slot
+          size_t target_slab = (first_slab + slab_distance) % set_associativity;
+          size_t slot_index =
+              (next_set * set_associativity + target_slab) * warp_size + slot_distance;
+
+          // Replace the LR slot
+          if (lane_idx == (size_t)next_lane) {
+            keys[next_set].set_[target_slab].slab_[slot_distance] = key;
+            slot_counter[slot_index] = global_counter->load(cuda::std::memory_order_relaxed);
+          }
+
+          warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
+                                    vals + slot_index * embedding_vec_size,
+                                    d_values + next_idx * embedding_vec_size);
+
+          // Replace complete, mark this task completed
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // The warp_tile read out the slab
+        key_type read_key = keys[next_set].set_[next_slab].slab_[lane_idx];
+
+        // Compare the slab data with the target key
+        int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
+
+        // If found target key, the insertion/replace is no longer needed.
+        // Refresh the slot, the task is completed
+        if (found_lane >= 0) {
+          size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
+          if (lane_idx == (size_t)next_lane) {
+            slot_counter[found_offset] = global_counter->load(cuda::std::memory_order_relaxed);
+            active = false;
+          }
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // Compare the slab data with empty key.
+        // If found empty key, do insertion,the task is complete
+        found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == empty_key))) - 1;
+        if (found_lane >= 0) {
+          size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
+
+          if (lane_idx == (size_t)next_lane) {
+            keys[next_set].set_[next_slab].slab_[found_lane] = key;
+            slot_counter[found_offset] = global_counter->load(cuda::std::memory_order_relaxed);
+          }
+
+          warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
+                                    vals + found_offset * embedding_vec_size,
+                                    d_values + next_idx * embedding_vec_size);
+
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // If no target or unused slot found in this slab,
+        // Refresh LR info, continue probing
+        ref_counter_type read_slot_counter =
+            slot_counter[(next_set * set_associativity + next_slab) * warp_size + lane_idx];
+        if (read_slot_counter < min_slot_counter_val) {
+          min_slot_counter_val = read_slot_counter;
+          slab_distance = counter;
+        }
+
+        counter++;
+        next_slab = (next_slab + 1) % set_associativity;
+      }
+
+      // Unlock the slabset after operating the slabset
+      warp_unlock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
+    }
   }
 }
 #else
@@ -721,150 +730,153 @@ __global__ void insert_replace_kernel(const key_type* d_keys, const float* d_val
                                       volatile int* set_mutex, ref_counter_type* global_counter,
                                       const size_t capacity_in_set,
                                       const size_t task_per_warp_tile) {
-  // Lane(thread) ID within a warp_tile
-  cg::thread_block_tile<warp_size> warp_tile =
-      cg::tiled_partition<warp_size>(cg::this_thread_block());
-  const size_t lane_idx = warp_tile.thread_rank();
-  // Warp tile global ID
-  const size_t warp_tile_global_idx =
-      (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
-  // The index of key for this thread
-  const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
-  // The assigned key for this lane(thread)
-  key_type key;
-  // The dst slabset and the dst slab inside this set
-  size_t src_set;
-  size_t src_slab;
-  // Active flag: whether current lane(thread) has unfinished task
-  bool active = false;
-  if (lane_idx < task_per_warp_tile) {
-    if (key_idx < len) {
-      active = true;
-      key = d_keys[key_idx];
-      src_set = set_hasher::hash(key) % capacity_in_set;
-      src_slab = slab_hasher::hash(key) % set_associativity;
-    }
-  }
-
-  // Lane participate in warp_tile ballot to produce warp-level work queue
-  unsigned active_mask = warp_tile.ballot(active);
-
-  // The warp-level outer loop: finish all the tasks within the work queue
-  while (active_mask != 0) {
-    // Next task in the work quere, start from lower index lane(thread)
-    int next_lane = __ffs(active_mask) - 1;
-    // Broadcast the task, the global index and the src slabset and slab to all lane in a warp_tile
-    key_type next_key = warp_tile.shfl(key, next_lane);
-    size_t next_idx = warp_tile.shfl(key_idx, next_lane);
-    size_t next_set = warp_tile.shfl(src_set, next_lane);
-    size_t next_slab = warp_tile.shfl(src_slab, next_lane);
-    size_t first_slab = next_slab;
-
-    // Counter to record how many slab have been searched
-    size_t counter = 0;
-
-    // Variable to keep the min slot counter during the probing
-    ref_counter_type min_slot_counter_val = max_ref_counter_type;
-    // Variable to keep the slab distance for slot with min counter
-    size_t slab_distance = max_slab_distance;
-    // Variable to keep the slot distance for slot with min counter within the slab
-    size_t slot_distance;
-    // Working queue before task started
-    const unsigned old_active_mask = active_mask;
-
-    // Lock the slabset before operating the slabset
-    warp_lock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
-
-    // The warp-level inner loop: finish a single task in the work queue
-    while (active_mask == old_active_mask) {
-      // When all the slabs inside a slabset have been searched
-      // and no empty slots or target slots are found. Replace with LRU
-      if (counter >= set_associativity) {
-        // (sub)Warp all-reduction, the reduction result store in all threads
-        warp_min_reduction<ref_counter_type, warp_size>(warp_tile, min_slot_counter_val,
-                                                        slab_distance, slot_distance);
-
-        // Calculate the position of LR slot
-        size_t target_slab = (first_slab + slab_distance) % set_associativity;
-        size_t slot_index =
-            (next_set * set_associativity + target_slab) * warp_size + slot_distance;
-
-        // Replace the LR slot
-        if (lane_idx == (size_t)next_lane) {
-          ((volatile key_type*)(keys[next_set].set_[target_slab].slab_))[slot_distance] = key;
-          slot_counter[slot_index] = atomicAdd(global_counter, 0);
-        }
-
-        warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
-                                  (volatile float*)(vals + slot_index * embedding_vec_size),
-                                  (volatile float*)(d_values + next_idx * embedding_vec_size));
-
-        // Replace complete, mark this task completed
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        active_mask = warp_tile.ballot(active);
-        break;
+  assert(warp_size <= warpSize);
+  if constexpr (warp_size <= warpSize) {
+    // Lane(thread) ID within a warp_tile
+    cg::thread_block_tile<warp_size> warp_tile =
+        cg::tiled_partition<warp_size>(cg::this_thread_block());
+    const size_t lane_idx = warp_tile.thread_rank();
+    // Warp tile global ID
+    const size_t warp_tile_global_idx =
+        (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
+    // The index of key for this thread
+    const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
+    // The assigned key for this lane(thread)
+    key_type key;
+    // The dst slabset and the dst slab inside this set
+    size_t src_set;
+    size_t src_slab;
+    // Active flag: whether current lane(thread) has unfinished task
+    bool active = false;
+    if (lane_idx < task_per_warp_tile) {
+      if (key_idx < len) {
+        active = true;
+        key = d_keys[key_idx];
+        src_set = set_hasher::hash(key) % capacity_in_set;
+        src_slab = slab_hasher::hash(key) % set_associativity;
       }
-
-      // The warp_tile read out the slab
-      key_type read_key = ((volatile key_type*)(keys[next_set].set_[next_slab].slab_))[lane_idx];
-
-      // Compare the slab data with the target key
-      int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
-
-      // If found target key, the insertion/replace is no longer needed.
-      // Refresh the slot, the task is completed
-      if (found_lane >= 0) {
-        size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
-        if (lane_idx == (size_t)next_lane) {
-          slot_counter[found_offset] = atomicAdd(global_counter, 0);
-          active = false;
-        }
-
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // Compare the slab data with empty key.
-      // If found empty key, do insertion,the task is complete
-      found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == empty_key))) - 1;
-      if (found_lane >= 0) {
-        size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
-
-        if (lane_idx == (size_t)next_lane) {
-          ((volatile key_type*)(keys[next_set].set_[next_slab].slab_))[found_lane] = key;
-          slot_counter[found_offset] = atomicAdd(global_counter, 0);
-        }
-
-        warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
-                                  (volatile float*)(vals + found_offset * embedding_vec_size),
-                                  (volatile float*)(d_values + next_idx * embedding_vec_size));
-
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // If no target or unused slot found in this slab,
-      // Refresh LR info, continue probing
-      ref_counter_type read_slot_counter =
-          slot_counter[(next_set * set_associativity + next_slab) * warp_size + lane_idx];
-      if (read_slot_counter < min_slot_counter_val) {
-        min_slot_counter_val = read_slot_counter;
-        slab_distance = counter;
-      }
-
-      counter++;
-      next_slab = (next_slab + 1) % set_associativity;
     }
 
-    // Unlock the slabset after operating the slabset
-    warp_unlock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
+    // Lane participate in warp_tile ballot to produce warp-level work queue
+    unsigned active_mask = warp_tile.ballot(active);
+
+    // The warp-level outer loop: finish all the tasks within the work queue
+    while (active_mask != 0) {
+      // Next task in the work quere, start from lower index lane(thread)
+      int next_lane = __ffs(active_mask) - 1;
+      // Broadcast the task, the global index and the src slabset and slab to all lane in a warp_tile
+      key_type next_key = warp_tile.shfl(key, next_lane);
+      size_t next_idx = warp_tile.shfl(key_idx, next_lane);
+      size_t next_set = warp_tile.shfl(src_set, next_lane);
+      size_t next_slab = warp_tile.shfl(src_slab, next_lane);
+      size_t first_slab = next_slab;
+
+      // Counter to record how many slab have been searched
+      size_t counter = 0;
+
+      // Variable to keep the min slot counter during the probing
+      ref_counter_type min_slot_counter_val = max_ref_counter_type;
+      // Variable to keep the slab distance for slot with min counter
+      size_t slab_distance = max_slab_distance;
+      // Variable to keep the slot distance for slot with min counter within the slab
+      size_t slot_distance;
+      // Working queue before task started
+      const unsigned old_active_mask = active_mask;
+
+      // Lock the slabset before operating the slabset
+      warp_lock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
+
+      // The warp-level inner loop: finish a single task in the work queue
+      while (active_mask == old_active_mask) {
+        // When all the slabs inside a slabset have been searched
+        // and no empty slots or target slots are found. Replace with LRU
+        if (counter >= set_associativity) {
+          // (sub)Warp all-reduction, the reduction result store in all threads
+          warp_min_reduction<ref_counter_type, warp_size>(warp_tile, min_slot_counter_val,
+                                                          slab_distance, slot_distance);
+
+          // Calculate the position of LR slot
+          size_t target_slab = (first_slab + slab_distance) % set_associativity;
+          size_t slot_index =
+              (next_set * set_associativity + target_slab) * warp_size + slot_distance;
+
+          // Replace the LR slot
+          if (lane_idx == (size_t)next_lane) {
+            ((volatile key_type*)(keys[next_set].set_[target_slab].slab_))[slot_distance] = key;
+            slot_counter[slot_index] = atomicAdd(global_counter, 0);
+          }
+
+          warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
+                                    (volatile float*)(vals + slot_index * embedding_vec_size),
+                                    (volatile float*)(d_values + next_idx * embedding_vec_size));
+
+          // Replace complete, mark this task completed
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // The warp_tile read out the slab
+        key_type read_key = ((volatile key_type*)(keys[next_set].set_[next_slab].slab_))[lane_idx];
+
+        // Compare the slab data with the target key
+        int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
+
+        // If found target key, the insertion/replace is no longer needed.
+        // Refresh the slot, the task is completed
+        if (found_lane >= 0) {
+          size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
+          if (lane_idx == (size_t)next_lane) {
+            slot_counter[found_offset] = atomicAdd(global_counter, 0);
+            active = false;
+          }
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // Compare the slab data with empty key.
+        // If found empty key, do insertion,the task is complete
+        found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == empty_key))) - 1;
+        if (found_lane >= 0) {
+          size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
+
+          if (lane_idx == (size_t)next_lane) {
+            ((volatile key_type*)(keys[next_set].set_[next_slab].slab_))[found_lane] = key;
+            slot_counter[found_offset] = atomicAdd(global_counter, 0);
+          }
+
+          warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
+                                    (volatile float*)(vals + found_offset * embedding_vec_size),
+                                    (volatile float*)(d_values + next_idx * embedding_vec_size));
+
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // If no target or unused slot found in this slab,
+        // Refresh LR info, continue probing
+        ref_counter_type read_slot_counter =
+            slot_counter[(next_set * set_associativity + next_slab) * warp_size + lane_idx];
+        if (read_slot_counter < min_slot_counter_val) {
+          min_slot_counter_val = read_slot_counter;
+          slab_distance = counter;
+        }
+
+        counter++;
+        next_slab = (next_slab + 1) % set_associativity;
+      }
+
+      // Unlock the slabset after operating the slabset
+      warp_unlock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
+    }
   }
 }
 #endif
@@ -878,105 +890,108 @@ __global__ void update_kernel(const key_type* d_keys, const size_t len, const fl
                               const size_t embedding_vec_size, const size_t capacity_in_set,
                               const slabset* keys, float* vals, mutex* set_mutex,
                               const size_t task_per_warp_tile) {
-  // Lane(thread) ID within a warp_tile
-  cg::thread_block_tile<warp_size> warp_tile =
-      cg::tiled_partition<warp_size>(cg::this_thread_block());
-  const size_t lane_idx = warp_tile.thread_rank();
-  // Warp tile global ID
-  const size_t warp_tile_global_idx =
-      (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
-  // The index of key for this thread
-  const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
-  // The assigned key for this lane(thread)
-  key_type key;
-  // The dst slabset and the dst slab inside this set
-  size_t src_set;
-  size_t src_slab;
-  // Active flag: whether current lane(thread) has unfinished task
-  bool active = false;
-  if (lane_idx < task_per_warp_tile) {
-    if (key_idx < len) {
-      active = true;
-      key = d_keys[key_idx];
-      src_set = set_hasher::hash(key) % capacity_in_set;
-      src_slab = slab_hasher::hash(key) % set_associativity;
-    }
-  }
-
-  // Lane participate in warp_tile ballot to produce warp-level work queue
-  unsigned active_mask = warp_tile.ballot(active);
-
-  // The warp-level outer loop: finish all the tasks within the work queue
-  while (active_mask != 0) {
-    // Next task in the work quere, start from lower index lane(thread)
-    int next_lane = __ffs(active_mask) - 1;
-    // Broadcast the task and the global index to all lane in the warp_tile
-    key_type next_key = warp_tile.shfl(key, next_lane);
-    size_t next_idx = warp_tile.shfl(key_idx, next_lane);
-    size_t next_set = warp_tile.shfl(src_set, next_lane);
-    size_t next_slab = warp_tile.shfl(src_slab, next_lane);
-
-    // Counter to record how many slab have been searched
-    size_t counter = 0;
-
-    // Working queue before task started
-    const unsigned old_active_mask = active_mask;
-
-    // Lock the slabset before operating the slabset
-    warp_lock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
-
-    // The warp-level inner loop: finish a single task in the work queue
-    while (active_mask == old_active_mask) {
-      // When all the slabs inside a slabset have been searched, mark missing task, do nothing, task
-      // complete
-      if (counter >= set_associativity) {
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        active_mask = warp_tile.ballot(active);
-        break;
+  assert(warp_size <= warpSize);
+  if constexpr (warp_size <= warpSize) {
+    // Lane(thread) ID within a warp_tile
+    cg::thread_block_tile<warp_size> warp_tile =
+        cg::tiled_partition<warp_size>(cg::this_thread_block());
+    const size_t lane_idx = warp_tile.thread_rank();
+    // Warp tile global ID
+    const size_t warp_tile_global_idx =
+        (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
+    // The index of key for this thread
+    const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
+    // The assigned key for this lane(thread)
+    key_type key;
+    // The dst slabset and the dst slab inside this set
+    size_t src_set;
+    size_t src_slab;
+    // Active flag: whether current lane(thread) has unfinished task
+    bool active = false;
+    if (lane_idx < task_per_warp_tile) {
+      if (key_idx < len) {
+        active = true;
+        key = d_keys[key_idx];
+        src_set = set_hasher::hash(key) % capacity_in_set;
+        src_slab = slab_hasher::hash(key) % set_associativity;
       }
-
-      // The warp_tile read out the slab
-      key_type read_key = keys[next_set].set_[next_slab].slab_[lane_idx];
-
-      // Compare the slab data with the target key
-      int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
-
-      // If found, mark hit task, update the value, the task is completed
-      if (found_lane >= 0) {
-        size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
-                                  vals + found_offset * embedding_vec_size,
-                                  d_values + next_idx * embedding_vec_size);
-
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // Compare the slab data with empty key, if found empty key, mark missing task, do nothing,
-      // task is completed
-      if (warp_tile.ballot(read_key == empty_key) != 0) {
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // Not found in this slab, the task is not completed, goto searching next slab
-      counter++;
-      next_slab = (next_slab + 1) % set_associativity;
     }
 
-    // Unlock the slabset after operating the slabset
-    warp_unlock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
+    // Lane participate in warp_tile ballot to produce warp-level work queue
+    unsigned active_mask = warp_tile.ballot(active);
+
+    // The warp-level outer loop: finish all the tasks within the work queue
+    while (active_mask != 0) {
+      // Next task in the work quere, start from lower index lane(thread)
+      int next_lane = __ffs(active_mask) - 1;
+      // Broadcast the task and the global index to all lane in the warp_tile
+      key_type next_key = warp_tile.shfl(key, next_lane);
+      size_t next_idx = warp_tile.shfl(key_idx, next_lane);
+      size_t next_set = warp_tile.shfl(src_set, next_lane);
+      size_t next_slab = warp_tile.shfl(src_slab, next_lane);
+
+      // Counter to record how many slab have been searched
+      size_t counter = 0;
+
+      // Working queue before task started
+      const unsigned old_active_mask = active_mask;
+
+      // Lock the slabset before operating the slabset
+      warp_lock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
+
+      // The warp-level inner loop: finish a single task in the work queue
+      while (active_mask == old_active_mask) {
+        // When all the slabs inside a slabset have been searched, mark missing task, do nothing, task
+        // complete
+        if (counter >= set_associativity) {
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // The warp_tile read out the slab
+        key_type read_key = keys[next_set].set_[next_slab].slab_[lane_idx];
+
+        // Compare the slab data with the target key
+        int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
+
+        // If found, mark hit task, update the value, the task is completed
+        if (found_lane >= 0) {
+          size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
+                                    vals + found_offset * embedding_vec_size,
+                                    d_values + next_idx * embedding_vec_size);
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // Compare the slab data with empty key, if found empty key, mark missing task, do nothing,
+        // task is completed
+        if (warp_tile.ballot(read_key == empty_key) != 0) {
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // Not found in this slab, the task is not completed, goto searching next slab
+        counter++;
+        next_slab = (next_slab + 1) % set_associativity;
+      }
+
+      // Unlock the slabset after operating the slabset
+      warp_unlock_mutex<mutex, warp_size>(warp_tile, set_mutex[next_set]);
+    }
   }
 }
 #else
@@ -988,105 +1003,108 @@ __global__ void update_kernel(const key_type* d_keys, const size_t len, const fl
                               const size_t embedding_vec_size, const size_t capacity_in_set,
                               volatile slabset* keys, volatile float* vals, volatile int* set_mutex,
                               const size_t task_per_warp_tile) {
-  // Lane(thread) ID within a warp_tile
-  cg::thread_block_tile<warp_size> warp_tile =
-      cg::tiled_partition<warp_size>(cg::this_thread_block());
-  const size_t lane_idx = warp_tile.thread_rank();
-  // Warp tile global ID
-  const size_t warp_tile_global_idx =
-      (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
-  // The index of key for this thread
-  const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
-  // The assigned key for this lane(thread)
-  key_type key;
-  // The dst slabset and the dst slab inside this set
-  size_t src_set;
-  size_t src_slab;
-  // Active flag: whether current lane(thread) has unfinished task
-  bool active = false;
-  if (lane_idx < task_per_warp_tile) {
-    if (key_idx < len) {
-      active = true;
-      key = d_keys[key_idx];
-      src_set = set_hasher::hash(key) % capacity_in_set;
-      src_slab = slab_hasher::hash(key) % set_associativity;
-    }
-  }
-
-  // Lane participate in warp_tile ballot to produce warp-level work queue
-  unsigned active_mask = warp_tile.ballot(active);
-
-  // The warp-level outer loop: finish all the tasks within the work queue
-  while (active_mask != 0) {
-    // Next task in the work quere, start from lower index lane(thread)
-    int next_lane = __ffs(active_mask) - 1;
-    // Broadcast the task and the global index to all lane in the warp_tile
-    key_type next_key = warp_tile.shfl(key, next_lane);
-    size_t next_idx = warp_tile.shfl(key_idx, next_lane);
-    size_t next_set = warp_tile.shfl(src_set, next_lane);
-    size_t next_slab = warp_tile.shfl(src_slab, next_lane);
-
-    // Counter to record how many slab have been searched
-    size_t counter = 0;
-
-    // Working queue before task started
-    const unsigned old_active_mask = active_mask;
-
-    // Lock the slabset before operating the slabset
-    warp_lock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
-
-    // The warp-level inner loop: finish a single task in the work queue
-    while (active_mask == old_active_mask) {
-      // When all the slabs inside a slabset have been searched, mark missing task, do nothing, task
-      // complete
-      if (counter >= set_associativity) {
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        active_mask = warp_tile.ballot(active);
-        break;
+  assert(warp_size <= warpSize);
+  if constexpr (warp_size <= warpSize) {
+    // Lane(thread) ID within a warp_tile
+    cg::thread_block_tile<warp_size> warp_tile =
+        cg::tiled_partition<warp_size>(cg::this_thread_block());
+    const size_t lane_idx = warp_tile.thread_rank();
+    // Warp tile global ID
+    const size_t warp_tile_global_idx =
+        (blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank();
+    // The index of key for this thread
+    const size_t key_idx = (warp_tile_global_idx * task_per_warp_tile) + lane_idx;
+    // The assigned key for this lane(thread)
+    key_type key;
+    // The dst slabset and the dst slab inside this set
+    size_t src_set;
+    size_t src_slab;
+    // Active flag: whether current lane(thread) has unfinished task
+    bool active = false;
+    if (lane_idx < task_per_warp_tile) {
+      if (key_idx < len) {
+        active = true;
+        key = d_keys[key_idx];
+        src_set = set_hasher::hash(key) % capacity_in_set;
+        src_slab = slab_hasher::hash(key) % set_associativity;
       }
-
-      // The warp_tile read out the slab
-      key_type read_key = ((volatile key_type*)(keys[next_set].set_[next_slab].slab_))[lane_idx];
-
-      // Compare the slab data with the target key
-      int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
-
-      // If found, mark hit task, update the value, the task is completed
-      if (found_lane >= 0) {
-        size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
-                                  (volatile float*)(vals + found_offset * embedding_vec_size),
-                                  (volatile float*)(d_values + next_idx * embedding_vec_size));
-
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // Compare the slab data with empty key, if found empty key, mark missing task, do nothing,
-      // task is completed
-      if (warp_tile.ballot(read_key == empty_key) != 0) {
-        if (lane_idx == (size_t)next_lane) {
-          active = false;
-        }
-
-        active_mask = warp_tile.ballot(active);
-        break;
-      }
-
-      // Not found in this slab, the task is not completed, goto searching next slab
-      counter++;
-      next_slab = (next_slab + 1) % set_associativity;
     }
 
-    // Unlock the slabset after operating the slabset
-    warp_unlock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
+    // Lane participate in warp_tile ballot to produce warp-level work queue
+    unsigned active_mask = warp_tile.ballot(active);
+
+    // The warp-level outer loop: finish all the tasks within the work queue
+    while (active_mask != 0) {
+      // Next task in the work quere, start from lower index lane(thread)
+      int next_lane = __ffs(active_mask) - 1;
+      // Broadcast the task and the global index to all lane in the warp_tile
+      key_type next_key = warp_tile.shfl(key, next_lane);
+      size_t next_idx = warp_tile.shfl(key_idx, next_lane);
+      size_t next_set = warp_tile.shfl(src_set, next_lane);
+      size_t next_slab = warp_tile.shfl(src_slab, next_lane);
+
+      // Counter to record how many slab have been searched
+      size_t counter = 0;
+
+      // Working queue before task started
+      const unsigned old_active_mask = active_mask;
+
+      // Lock the slabset before operating the slabset
+      warp_lock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
+
+      // The warp-level inner loop: finish a single task in the work queue
+      while (active_mask == old_active_mask) {
+        // When all the slabs inside a slabset have been searched, mark missing task, do nothing, task
+        // complete
+        if (counter >= set_associativity) {
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // The warp_tile read out the slab
+        key_type read_key = ((volatile key_type*)(keys[next_set].set_[next_slab].slab_))[lane_idx];
+
+        // Compare the slab data with the target key
+        int found_lane = __ffs(static_cast<unsigned int>(warp_tile.ballot(read_key == next_key))) - 1;
+
+        // If found, mark hit task, update the value, the task is completed
+        if (found_lane >= 0) {
+          size_t found_offset = (next_set * set_associativity + next_slab) * warp_size + found_lane;
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          warp_tile_copy<warp_size>(lane_idx, embedding_vec_size,
+                                    (volatile float*)(vals + found_offset * embedding_vec_size),
+                                    (volatile float*)(d_values + next_idx * embedding_vec_size));
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // Compare the slab data with empty key, if found empty key, mark missing task, do nothing,
+        // task is completed
+        if (warp_tile.ballot(read_key == empty_key) != 0) {
+          if (lane_idx == (size_t)next_lane) {
+            active = false;
+          }
+
+          active_mask = warp_tile.ballot(active);
+          break;
+        }
+
+        // Not found in this slab, the task is not completed, goto searching next slab
+        counter++;
+        next_slab = (next_slab + 1) % set_associativity;
+      }
+
+      // Unlock the slabset after operating the slabset
+      warp_unlock_mutex<warp_size>(warp_tile, set_mutex[next_set]);
+    }
   }
 }
 #endif
@@ -1097,71 +1115,74 @@ template <typename key_type, typename slabset, typename mutex, key_type empty_ke
 __global__ void dump_kernel(key_type* d_keys, size_t* d_dump_counter, const slabset* keys,
                             mutex* set_mutex, const size_t start_set_index,
                             const size_t end_set_index) {
-  // Block-level counter used by all warp tiles within a block
-  __shared__ uint32_t block_acc;
-  // Initialize block-level counter
-  if (threadIdx.x == 0) {
-    block_acc = 0;
-  }
-  __syncthreads();
-  // Lane(thread) ID within a warp tile
-  cg::thread_block_tile<warp_size> warp_tile =
-      cg::tiled_partition<warp_size>(cg::this_thread_block());
-  const size_t lane_idx = warp_tile.thread_rank();
-  // Warp tile target slabset id
-  const size_t set_idx =
-      ((blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank()) + start_set_index;
-  // Keys dump from cache
-  key_type read_key[set_associativity];
-  // Lane(thread) offset for storing each key
-  uint32_t thread_key_offset[set_associativity];
-  // Warp offset for storing each key
-  uint32_t warp_key_offset;
-  // Block offset for storing each key
-  __shared__ size_t block_key_offset;
+  assert(warp_size <= warpSize);
+  if constexpr (warp_size <= warpSize) {
+    // Block-level counter used by all warp tiles within a block
+    __shared__ uint32_t block_acc;
+    // Initialize block-level counter
+    if (threadIdx.x == 0) {
+      block_acc = 0;
+    }
+    __syncthreads();
+    // Lane(thread) ID within a warp tile
+    cg::thread_block_tile<warp_size> warp_tile =
+        cg::tiled_partition<warp_size>(cg::this_thread_block());
+    const size_t lane_idx = warp_tile.thread_rank();
+    // Warp tile target slabset id
+    const size_t set_idx =
+        ((blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank()) + start_set_index;
+    // Keys dump from cache
+    key_type read_key[set_associativity];
+    // Lane(thread) offset for storing each key
+    uint32_t thread_key_offset[set_associativity];
+    // Warp offset for storing each key
+    uint32_t warp_key_offset;
+    // Block offset for storing each key
+    __shared__ size_t block_key_offset;
 
-  // Warp tile dump target slabset
-  if (set_idx < end_set_index) {
-    // Lock the slabset before operating the slabset
-    warp_lock_mutex<mutex, warp_size>(warp_tile, set_mutex[set_idx]);
+    // Warp tile dump target slabset
+    if (set_idx < end_set_index) {
+      // Lock the slabset before operating the slabset
+      warp_lock_mutex<mutex, warp_size>(warp_tile, set_mutex[set_idx]);
 
-    // The warp tile read out the slabset
-    for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
-      // The warp tile read out a slab
-      read_key[slab_id] = keys[set_idx].set_[slab_id].slab_[lane_idx];
+      // The warp tile read out the slabset
+      for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
+        // The warp tile read out a slab
+        read_key[slab_id] = keys[set_idx].set_[slab_id].slab_[lane_idx];
+      }
+
+      // Finish dumping the slabset, unlock the slabset
+      warp_unlock_mutex<mutex, warp_size>(warp_tile, set_mutex[set_idx]);
+
+      // Each lane(thread) within the warp tile calculate the offset to store its keys
+      uint32_t warp_tile_total_keys = 0;
+      for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
+        unsigned valid_mask = warp_tile.ballot(read_key[slab_id] != empty_key);
+        thread_key_offset[slab_id] =
+            __popc(valid_mask & ((1U << lane_idx) - 1U)) + warp_tile_total_keys;
+        warp_tile_total_keys = warp_tile_total_keys + __popc(valid_mask);
+      }
+
+      // Each warp tile request a unique place from the block-level counter
+      if (lane_idx == 0) {
+        warp_key_offset = atomicAdd(&block_acc, warp_tile_total_keys);
+      }
+      warp_key_offset = warp_tile.shfl(warp_key_offset, 0);
     }
 
-    // Finish dumping the slabset, unlock the slabset
-    warp_unlock_mutex<mutex, warp_size>(warp_tile, set_mutex[set_idx]);
-
-    // Each lane(thread) within the warp tile calculate the offset to store its keys
-    uint32_t warp_tile_total_keys = 0;
-    for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
-      unsigned valid_mask = warp_tile.ballot(read_key[slab_id] != empty_key);
-      thread_key_offset[slab_id] =
-          __popc(valid_mask & ((1U << lane_idx) - 1U)) + warp_tile_total_keys;
-      warp_tile_total_keys = warp_tile_total_keys + __popc(valid_mask);
+    // Each block request a unique place in global memory output buffer
+    __syncthreads();
+    if (threadIdx.x == 0) {
+      block_key_offset = atomicAdd(d_dump_counter, (size_t)block_acc);
     }
+    __syncthreads();
 
-    // Each warp tile request a unique place from the block-level counter
-    if (lane_idx == 0) {
-      warp_key_offset = atomicAdd(&block_acc, warp_tile_total_keys);
-    }
-    warp_key_offset = warp_tile.shfl(warp_key_offset, 0);
-  }
-
-  // Each block request a unique place in global memory output buffer
-  __syncthreads();
-  if (threadIdx.x == 0) {
-    block_key_offset = atomicAdd(d_dump_counter, (size_t)block_acc);
-  }
-  __syncthreads();
-
-  // Warp tile store the (non-empty)keys back to output buffer
-  if (set_idx < end_set_index) {
-    for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
-      if (read_key[slab_id] != empty_key) {
-        d_keys[block_key_offset + warp_key_offset + thread_key_offset[slab_id]] = read_key[slab_id];
+    // Warp tile store the (non-empty)keys back to output buffer
+    if (set_idx < end_set_index) {
+      for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
+        if (read_key[slab_id] != empty_key) {
+          d_keys[block_key_offset + warp_key_offset + thread_key_offset[slab_id]] = read_key[slab_id];
+        }
       }
     }
   }
@@ -1172,71 +1193,74 @@ template <typename key_type, typename slabset, key_type empty_key, int set_assoc
 __global__ void dump_kernel(key_type* d_keys, size_t* d_dump_counter, volatile slabset* keys,
                             volatile int* set_mutex, const size_t start_set_index,
                             const size_t end_set_index) {
-  // Block-level counter used by all warp tiles within a block
-  __shared__ uint32_t block_acc;
-  // Initialize block-level counter
-  if (threadIdx.x == 0) {
-    block_acc = 0;
-  }
-  __syncthreads();
-  // Lane(thread) ID within a warp tile
-  cg::thread_block_tile<warp_size> warp_tile =
-      cg::tiled_partition<warp_size>(cg::this_thread_block());
-  const size_t lane_idx = warp_tile.thread_rank();
-  // Warp tile target slabset id
-  const size_t set_idx =
-      ((blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank()) + start_set_index;
-  // Keys dump from cache
-  key_type read_key[set_associativity];
-  // Lane(thread) offset for storing each key
-  uint32_t thread_key_offset[set_associativity];
-  // Warp offset for storing each key
-  uint32_t warp_key_offset;
-  // Block offset for storing each key
-  __shared__ size_t block_key_offset;
+  assert(warp_size <= warpSize);
+  if constexpr (warp_size <= warpSize) {
+    // Block-level counter used by all warp tiles within a block
+    __shared__ uint32_t block_acc;
+    // Initialize block-level counter
+    if (threadIdx.x == 0) {
+      block_acc = 0;
+    }
+    __syncthreads();
+    // Lane(thread) ID within a warp tile
+    cg::thread_block_tile<warp_size> warp_tile =
+        cg::tiled_partition<warp_size>(cg::this_thread_block());
+    const size_t lane_idx = warp_tile.thread_rank();
+    // Warp tile target slabset id
+    const size_t set_idx =
+        ((blockIdx.x * (blockDim.x / warp_size)) + warp_tile.meta_group_rank()) + start_set_index;
+    // Keys dump from cache
+    key_type read_key[set_associativity];
+    // Lane(thread) offset for storing each key
+    uint32_t thread_key_offset[set_associativity];
+    // Warp offset for storing each key
+    uint32_t warp_key_offset;
+    // Block offset for storing each key
+    __shared__ size_t block_key_offset;
 
-  // Warp tile dump target slabset
-  if (set_idx < end_set_index) {
-    // Lock the slabset before operating the slabset
-    warp_lock_mutex<warp_size>(warp_tile, set_mutex[set_idx]);
+    // Warp tile dump target slabset
+    if (set_idx < end_set_index) {
+      // Lock the slabset before operating the slabset
+      warp_lock_mutex<warp_size>(warp_tile, set_mutex[set_idx]);
 
-    // The warp tile read out the slabset
-    for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
-      // The warp tile read out a slab
-      read_key[slab_id] = ((volatile key_type*)(keys[set_idx].set_[slab_id].slab_))[lane_idx];
+      // The warp tile read out the slabset
+      for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
+        // The warp tile read out a slab
+        read_key[slab_id] = ((volatile key_type*)(keys[set_idx].set_[slab_id].slab_))[lane_idx];
+      }
+
+      // Finish dumping the slabset, unlock the slabset
+      warp_unlock_mutex<warp_size>(warp_tile, set_mutex[set_idx]);
+
+      // Each lane(thread) within the warp tile calculate the offset to store its keys
+      uint32_t warp_tile_total_keys = 0;
+      for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
+        unsigned valid_mask = warp_tile.ballot(read_key[slab_id] != empty_key);
+        thread_key_offset[slab_id] =
+            __popc(valid_mask & ((1U << lane_idx) - 1U)) + warp_tile_total_keys;
+        warp_tile_total_keys = warp_tile_total_keys + __popc(valid_mask);
+      }
+
+      // Each warp tile request a unique place from the block-level counter
+      if (lane_idx == 0) {
+        warp_key_offset = atomicAdd(&block_acc, warp_tile_total_keys);
+      }
+      warp_key_offset = warp_tile.shfl(warp_key_offset, 0);
     }
 
-    // Finish dumping the slabset, unlock the slabset
-    warp_unlock_mutex<warp_size>(warp_tile, set_mutex[set_idx]);
-
-    // Each lane(thread) within the warp tile calculate the offset to store its keys
-    uint32_t warp_tile_total_keys = 0;
-    for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
-      unsigned valid_mask = warp_tile.ballot(read_key[slab_id] != empty_key);
-      thread_key_offset[slab_id] =
-          __popc(valid_mask & ((1U << lane_idx) - 1U)) + warp_tile_total_keys;
-      warp_tile_total_keys = warp_tile_total_keys + __popc(valid_mask);
+    // Each block request a unique place in global memory output buffer
+    __syncthreads();
+    if (threadIdx.x == 0) {
+      block_key_offset = atomicAdd(d_dump_counter, (size_t)block_acc);
     }
+    __syncthreads();
 
-    // Each warp tile request a unique place from the block-level counter
-    if (lane_idx == 0) {
-      warp_key_offset = atomicAdd(&block_acc, warp_tile_total_keys);
-    }
-    warp_key_offset = warp_tile.shfl(warp_key_offset, 0);
-  }
-
-  // Each block request a unique place in global memory output buffer
-  __syncthreads();
-  if (threadIdx.x == 0) {
-    block_key_offset = atomicAdd(d_dump_counter, (size_t)block_acc);
-  }
-  __syncthreads();
-
-  // Warp tile store the (non-empty)keys back to output buffer
-  if (set_idx < end_set_index) {
-    for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
-      if (read_key[slab_id] != empty_key) {
-        d_keys[block_key_offset + warp_key_offset + thread_key_offset[slab_id]] = read_key[slab_id];
+    // Warp tile store the (non-empty)keys back to output buffer
+    if (set_idx < end_set_index) {
+      for (unsigned slab_id = 0; slab_id < set_associativity; slab_id++) {
+        if (read_key[slab_id] != empty_key) {
+          d_keys[block_key_offset + warp_key_offset + thread_key_offset[slab_id]] = read_key[slab_id];
+        }
       }
     }
   }


### PR DESCRIPTION
Rather than using a compile-time constant macro, we use a runtime variable, per https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_porting_guide.html#warpsize, https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_cpp_language_extensions.html#warp-size, and https://github.com/ROCm/ROCm/releases/tag/rocm-6.4.0#:~:text=AMDGPU%20wavefront%20size%20compiler%20macro%20deprecation.

DO NOT SUBMIT: This is a draft on top of the already hipified code. It would need to be converted into the necessary pre-hip changes and rebased on the hip-ready branch before merging.

There are a few places, particularly around the GPU cache, that really want this to be a compile time constant and use it (or derived values) as array sizes and such. Here I basically used switches to select at runtime one of the two supported warp sizes. There are some neat tricks for doing this demonstrated in https://rocm.docs.amd.com/projects/HIP/en/docs-develop/tutorial/reduction.html, but unfortunately they require C++20 features. I did at some point create a wrapper macro to avoid duplicating code on each branch of the switch, but this ended up only being used in one place, so I dropped it.

Another tricky thing is that DGL's objects that are exposed in Python really want to be a single type so using a templated class creates issues. There were some existing workarounds for this for the GPU cache key type, but adding another template parameter would have again doubled the branches in every method and also it turns out to be quite difficult to correctly pass a templated class name to a function-like macro because it splits the argument at the comma (and you can't have class declarations inside parentheses). So instead I created non-templated virtual base classes and used containers for those and then a single switch to create the correct type on construction.

Since I was already markedly changing the type declarations for the nv_gpu_cache, I went ahead and changed the key types from `unsigned int` and `long long` to `uint32_t` and `uint64_t`. This allowed removing some static asserts DGL had to do about the size of the types and it seems much more sensible to use fixed-size types here.

After all this, I tried compiling for gfx1100 and it *still* fails. There are apparently multiple places in HIP that static assert that the warp size isn't too big:

<details>
<summary>Compilation errors for gfx1100</summary>

```
In file included from ../../../third_party/HugeCTR/gpu_cache/src/nv_gpu_cache.cu:18:
In file included from /opt/rocm-6.4.0/lib/llvm/bin/../../../include/hip/hip_cooperative_groups.h:38:
/opt/rocm-6.4.0/lib/llvm/bin/../../../include/hip/amd_detail/amd_hip_cooperative_groups.h:660:17: error: static assertion failed due to requirement 'integral_constant<bool, false>::value': Tile size is either not a power of 2 or greater than the wavefront size
  660 |   static_assert(is_valid_tile_size<size>::value,
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/rocm-6.4.0/lib/llvm/bin/../../../include/hip/amd_detail/amd_hip_cooperative_groups.h:746:39: note: in instantiation of template class 'cooperative_groups::thread_block_tile_base<64>' requested here
  746 | class thread_block_tile_type : public thread_block_tile_base<tileSize>,
      |                                       ^
/opt/rocm-6.4.0/lib/llvm/bin/../../../include/hip/amd_detail/amd_hip_cooperative_groups.h:843:43: note: in instantiation of template class 'cooperative_groups::thread_block_tile_type<64, cooperative_groups::thread_block>' requested here
  843 | class thread_block_tile_internal : public thread_block_tile_type<size, ParentCGTy> {
      |                                           ^
/opt/rocm-6.4.0/lib/llvm/bin/../../../include/hip/amd_detail/amd_hip_cooperative_groups.h:856:34: note: in instantiation of template class 'cooperative_groups::impl::thread_block_tile_internal<64, cooperative_groups::thread_block>' requested here
  856 | class thread_block_tile : public impl::thread_block_tile_internal<size, ParentCGTy> {
      |                                  ^
../../../third_party/HugeCTR/gpu_cache/src/nv_gpu_cache.cu:267:7: note: in instantiation of template class 'cooperative_groups::thread_block_tile<64, cooperative_groups::thread_block>' requested here
  267 |       cg::tiled_partition<warp_size>(cg::this_thread_block());
      |       ^
../../../third_party/HugeCTR/gpu_cache/src/nv_gpu_cache.cu:1431:3: note: in instantiation of function template specialization 'gpu_cache::get_kernel<unsigned int, unsigned long, cuda::atomic<unsigned long, cuda::std::__detail::thread_scope_device>, gpu_cache::slab_set<2, unsigned int, 64>, MurmurHash3_32<unsigned int>, Mod_Hash<unsigned int, unsigned long>, cuda::counting_semaphore<cuda::std::__detail::thread_scope_device, 1>, 4294967295U, 2, 64>' requested here
 1431 |   get_kernel<key_type, ref_counter_type, atomic_ref_counter_type, slabset, set_hasher, slab_hasher,
      |   ^
```

```
In file included from ../../../third_party/HugeCTR/gpu_cache/src/nv_gpu_cache.cu:18:
In file included from /opt/rocm-6.4.0/lib/llvm/bin/../../../include/hip/hip_cooperative_groups.h:38:
/opt/rocm-6.4.0/lib/llvm/bin/../../../include/hip/amd_detail/amd_hip_cooperative_groups.h:899:17: error: static assertion failed due to requirement 'integral_constant<bool, false>::value': Tiled partition with size > wavefront size. Currently not supported
  899 |   static_assert(is_valid_tile_size<size>::value,
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../third_party/HugeCTR/gpu_cache/src/nv_gpu_cache.cu:267:11: note: in instantiation of function template specialization 'cooperative_groups::tiled_partition<64U, cooperative_groups::thread_block>' requested here
  267 |       cg::tiled_partition<warp_size>(cg::this_thread_block());
      |           ^
../../../third_party/HugeCTR/gpu_cache/src/nv_gpu_cache.cu:1431:3: note: in instantiation of function template specialization 'gpu_cache::get_kernel<unsigned int, unsigned long, cuda::atomic<unsigned long, cuda::std::__detail::thread_scope_device>, gpu_cache::slab_set<2, unsigned int, 64>, MurmurHash3_32<unsigned int>, Mod_Hash<unsigned int, unsigned long>, cuda::counting_semaphore<cuda::std::__detail::thread_scope_device, 1>, 4294967295U, 2, 64>' requested here
 1431 |   get_kernel<key_type, ref_counter_type, atomic_ref_counter_type, slabset, set_hasher, slab_hasher,
      |   ^
```

</details>

So even instantiating these templates with warp size 64 causes failures. That code is just checking it against the now-deprecated `__AMDGCN_WAVEFRONT_SIZE`. I think that means that it is actually not possible to make warp size a runtime decision right now as constructed by HIP itself 🤦  I'm also confused because I thought RDNA was supposed to support warp sizes of 32 or 64 depending on some mode. If I drop the explicit template instantiations in nv_gpu_cache.cu then I can get compilation to complete, but get later linking errors because the DGL code can't find those templates that were never actually created.

As a side note, there's a compilation warning that appears to be triggered by just compiling libhipcxx for gfx1100 at all, which means it can't be compiled with `-Werror`. I'm not sure how to get around this.

```
In file included from ../../../third_party/HugeCTR/gpu_cache/src/nv_gpu_cache.cu:21:
In file included from ../../../third_party/HugeCTR/gpu_cache/include/nv_gpu_cache.hpp:26:
In file included from /opt/rocm-6.4.0/lib/llvm/bin/../../../include/cuda/atomic:14:
In file included from /opt/rocm-6.4.0/lib/llvm/bin/../../../include/cuda/std/atomic:14:
In file included from /opt/rocm-6.4.0/lib/llvm/bin/../../../include/cuda/std/detail/__config:43:
/opt/rocm-6.4.0/lib/llvm/bin/../../../include/cuda/std/detail/libcxx/include/__config:2232:2: error: Assuming 100 MHz realtime clock rate (TSC) for gfx1100/gfx1101 (according to the RDNA3 ISA). Timing-related APIs (e.g., chrono) or sleep instructions may behave incorrectly! [-Werror,-W#warnings]
 2232 | #warning Assuming 100 MHz realtime clock rate (TSC) for gfx1100/gfx1101 (according to the RDNA3 ISA). Timing-related APIs (e.g., chrono) or sleep instructions may behave incorrectly!
      |  ^
1 error generated when compiling for gfx1100
```

But on the MI210 gfx90a, all the C++ and Python unit tests pass.