### PR TITLE
Fix some errors introduced for Nvidia GPUs

### DIFF
--- a/graphbolt/src/cuda/extension/unique_and_compact_map.cu
+++ b/graphbolt/src/cuda/extension/unique_and_compact_map.cu
@@ -26,8 +26,7 @@
 #include <cub/cub.cuh>
 
 #include <cuco/static_map.cuh>
-// libhipcxx does not provide proclaim_return_type, but hipCollections defines
-// it.
+// cuda/functional doesn't exist for HIP
 #ifndef GRAPHBOLT_USE_ROCM
 #include <cuda/functional>
 #endif

--- a/graphbolt/src/cuda/extension/unique_and_compact_map.cu
+++ b/graphbolt/src/cuda/extension/unique_and_compact_map.cu
@@ -25,11 +25,10 @@
 
 #include <cub/cub.cuh>
 
-#ifdef GRAPHBOLT_USE_ROCM
+#include <cuco/static_map.cuh>
 // libhipcxx does not provide proclaim_return_type, but hipCollections defines
 // it.
-#include <cuco/static_map.cuh>
-#else
+#ifndef GRAPHBOLT_USE_ROCM
 #include <cuda/functional>
 #endif
 

--- a/src/array/cuda/spmm.cuh
+++ b/src/array/cuda/spmm.cuh
@@ -24,7 +24,7 @@ using namespace cuda;
 #ifdef DGL_USE_ROCM
 #define CUSPARSE_IS_LEGACY 0
 #else
-#define CUSPARSE_IS_LEGACY CUDART_VERSION >= 11000
+#define CUSPARSE_IS_LEGACY CUDART_VERSION < 11000
 #endif
 
 namespace aten {


### PR DESCRIPTION
The conditional was inverted for `CUSPARSE_IS_LEGACY` and an ifdef erroneously excluded a header in the `DGL_USE_CUDA` case.

Discovered while running this version on Nvidia. Otherwise it seems like everything works fine.