### PR TITLE
Do a development install of DGL in the container

### DIFF
--- a/docker/Dockerfile.rocm-complete
+++ b/docker/Dockerfile.rocm-complete
@@ -89,5 +89,6 @@ RUN --mount=type=cache,target=/root/.cache/ccache \
     && ccache -vvv --show-log-stats \
     && rm "${CCACHE_STATSLOG}" \
     && cd python \
-    && python setup.py install \
+    # We do a development install here so people can hack on the DGL python from inside the container
+    && python setup.py develop \
     && python setup.py build_ext --inplace


### PR DESCRIPTION
This makes it possible to hack on DGL in there, which seems useful. I don't think there are really a lot of downsides to doing this in a single-purpose docker container.
